### PR TITLE
Add clipboard image paste support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v1.3.4
+
+### New Features
+
+- **Clipboard image paste**: Screenshot to clipboard, then Ctrl+V (or Cmd+V on macOS) pastes the image as a temp file path — useful for sharing screenshots with AI tools like Claude Code and Copilot
+
+### Fixes
+
+- **macOS paste**: Paste shortcuts (Ctrl+V / Cmd+V) now work correctly on macOS across main and detached terminal windows

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,6 @@
 import { app, BrowserWindow, ipcMain, Menu, shell } from 'electron';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import Store from 'electron-store';
 import { PtyManager } from './pty-manager';
@@ -326,6 +328,15 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(IPC.VERSION_CHECK_NOW, () => {
     return versionChecker?.checkNow() ?? null;
+  });
+
+  ipcMain.handle(IPC.CLIPBOARD_SAVE_IMAGE, (_event, base64Png: string) => {
+    const dir = path.join(os.tmpdir(), 'tmax-clipboard');
+    fs.mkdirSync(dir, { recursive: true });
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filePath = path.join(dir, `clipboard-${timestamp}.png`);
+    fs.writeFileSync(filePath, Buffer.from(base64Png, 'base64'));
+    return filePath;
   });
 }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -20,6 +20,8 @@ export interface TerminalAPI {
   setConfig(key: string, value: unknown): Promise<void>;
   clipboardRead(): string;
   clipboardWrite(text: string): void;
+  clipboardHasImage(): boolean;
+  clipboardSaveImage(): Promise<string>;
   getAppVersion(): Promise<string>;
   getVersionUpdate(): Promise<{ current: string; latest: string; url: string } | null>;
   checkForUpdates(): Promise<{ current: string; latest: string; url: string } | null>;
@@ -77,6 +79,16 @@ const terminalAPI: TerminalAPI = {
 
   clipboardWrite(text: string) {
     clipboard.writeText(text);
+  },
+
+  clipboardHasImage() {
+    return !clipboard.readImage().isEmpty();
+  },
+
+  clipboardSaveImage() {
+    const png = clipboard.readImage().toPNG();
+    const base64 = png.toString('base64');
+    return ipcRenderer.invoke(IPC.CLIPBOARD_SAVE_IMAGE, base64);
   },
 
   openConfigFile() {

--- a/src/renderer/DetachedApp.tsx
+++ b/src/renderer/DetachedApp.tsx
@@ -52,13 +52,19 @@ const DetachedApp: React.FC<DetachedAppProps> = ({ terminalId }) => {
       // Clipboard paste/copy handling
       term.attachCustomKeyEventHandler((event) => {
         if (event.type !== 'keydown') return true;
-        if (event.ctrlKey && (event.key === 'v' || event.key === 'V')) {
-          navigator.clipboard
-            .readText()
-            .then((text) => {
-              if (text) window.terminalAPI.writePty(terminalId, text);
-            })
-            .catch(() => {});
+        if ((event.ctrlKey || event.metaKey) && (event.key === 'v' || event.key === 'V')) {
+          if (window.terminalAPI.clipboardHasImage()) {
+            window.terminalAPI.clipboardSaveImage().then((filePath) => {
+              window.terminalAPI.writePty(terminalId, filePath);
+            });
+          } else {
+            navigator.clipboard
+              .readText()
+              .then((text) => {
+                if (text) window.terminalAPI.writePty(terminalId, text);
+              })
+              .catch(() => {});
+          }
           return false;
         }
         if (event.ctrlKey && !event.shiftKey && event.key === 'c' && term.hasSelection()) {

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -86,11 +86,17 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
         requestAnimationFrame(() => searchInputRef.current?.focus());
         return false;
       }
-      // Ctrl+V or Ctrl+Shift+V: paste
-      if (event.ctrlKey && (event.key === 'v' || event.key === 'V')) {
+      // Ctrl+V / Cmd+V or Ctrl+Shift+V: paste
+      if ((event.ctrlKey || event.metaKey) && (event.key === 'v' || event.key === 'V')) {
         event.preventDefault(); // Stop browser native paste (would cause double paste)
-        const text = window.terminalAPI.clipboardRead();
-        if (text) window.terminalAPI.writePty(terminalId, text);
+        if (window.terminalAPI.clipboardHasImage()) {
+          window.terminalAPI.clipboardSaveImage().then((filePath) => {
+            window.terminalAPI.writePty(terminalId, filePath);
+          });
+        } else {
+          const text = window.terminalAPI.clipboardRead();
+          if (text) window.terminalAPI.writePty(terminalId, text);
+        }
         return false;
       }
       // Ctrl+C with selection: copy instead of SIGINT
@@ -271,8 +277,14 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
         window.terminalAPI.clipboardWrite(term.getSelection());
         term.clearSelection();
       } else {
-        const text = window.terminalAPI.clipboardRead();
-        if (text) window.terminalAPI.writePty(terminalId, text);
+        if (window.terminalAPI.clipboardHasImage()) {
+          window.terminalAPI.clipboardSaveImage().then((filePath) => {
+            window.terminalAPI.writePty(terminalId, filePath);
+          });
+        } else {
+          const text = window.terminalAPI.clipboardRead();
+          if (text) window.terminalAPI.writePty(terminalId, text);
+        }
       }
     };
     // Use capture phase to intercept before any other handler

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -37,6 +37,7 @@ export const IPC = {
   VERSION_GET_UPDATE: 'version:getUpdate',
   VERSION_CHECK_NOW: 'version:checkNow',
   VERSION_GET_APP_VERSION: 'version:getAppVersion',
+  CLIPBOARD_SAVE_IMAGE: 'clipboard:saveImage',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];


### PR DESCRIPTION
## Summary

- Detect images on the clipboard when pasting (Ctrl+V / Cmd+V or right-click), save as PNG to a temp directory (`os.tmpdir()/tmax-clipboard/`), and insert the file path into the terminal
- Enables sharing screenshots directly with AI tools like Claude Code and Copilot
- Fixes paste shortcut on macOS by checking both `ctrlKey` and `metaKey` in all paste handlers (main window, detached window, and right-click)

## Changed files

| File | Change |
|------|--------|
| `src/shared/ipc-channels.ts` | New `CLIPBOARD_SAVE_IMAGE` IPC channel |
| `src/main/main.ts` | IPC handler to save PNG buffer to temp dir |
| `src/preload/preload.ts` | `clipboardHasImage()` (sync) and `clipboardSaveImage()` (async) APIs |
| `src/renderer/components/TerminalPanel.tsx` | Image-first paste for Ctrl+V/Cmd+V and right-click |
| `src/renderer/DetachedApp.tsx` | Image-first paste for detached windows |
| `CHANGELOG.md` | New changelog file with v1.3.4 entry |

## Test plan

- [x] `npm start` → screenshot to clipboard → Ctrl+V → temp file path appears in terminal
- [x] Verify the file at that path is a valid PNG
- [x] Copy plain text → Ctrl+V → text pastes normally (no regression)
- [x] Right-click paste with image clipboard → file path pasted
- [x] Right-click paste with text clipboard → text pasted
- [x] Test in a detached terminal window
- [ ] Verify on macOS with Cmd+V (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)