### PR TITLE
feat: add auto-update support for Windows/macOS with GitHub fallback (#6)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,6 +13,12 @@ import { ClaudeCodeSessionMonitor } from './claude-code-session-monitor';
 import { ClaudeCodeSessionWatcher } from './claude-code-session-watcher';
 import { VersionChecker } from './version-checker';
 
+// Handle Squirrel.Windows lifecycle events (install, update, uninstall)
+// Must be at the top before any other initialization
+if (process.platform === 'win32' && process.argv[1]?.startsWith('--squirrel-')) {
+  app.quit();
+}
+
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
 
@@ -326,8 +332,12 @@ function registerIpcHandlers(): void {
     return versionChecker?.getUpdateInfo() ?? null;
   });
 
-  ipcMain.handle(IPC.VERSION_CHECK_NOW, () => {
-    return versionChecker?.checkNow() ?? null;
+  ipcMain.on(IPC.VERSION_CHECK_NOW, () => {
+    versionChecker?.checkNow();
+  });
+
+  ipcMain.on(IPC.VERSION_RESTART_AND_UPDATE, () => {
+    versionChecker?.restartAndUpdate();
   });
 
   ipcMain.handle(IPC.CLIPBOARD_SAVE_IMAGE, (_event, base64Png: string) => {

--- a/src/main/version-checker.ts
+++ b/src/main/version-checker.ts
@@ -1,45 +1,48 @@
-import { app, Notification, BrowserWindow } from 'electron';
+import { app, autoUpdater, Notification, BrowserWindow } from 'electron';
 import Store from 'electron-store';
 import { IPC } from '../shared/ipc-channels';
 
-const GITHUB_RELEASES_URL = 'https://api.github.com/repos/InbarR/tmax/releases/latest';
+const GITHUB_REPO = 'InbarR/tmax';
+const UPDATE_SERVER = 'https://update.electronjs.org';
+const GITHUB_RELEASES_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const INITIAL_DELAY_MS = 5000;
 
-interface VersionInfo {
+export type UpdateStatus = 'idle' | 'checking' | 'downloading' | 'downloaded' | 'available' | 'error';
+
+export interface UpdateInfo {
+  status: UpdateStatus;
   current: string;
-  latest: string;
-  url: string;
-}
-
-const versionStore = new Store({ name: 'tmax-version-check' });
-
-function compareVersions(a: string, b: string): number {
-  const pa = a.replace(/^v/, '').split('.').map(Number);
-  const pb = b.replace(/^v/, '').split('.').map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const na = pa[i] ?? 0;
-    const nb = pb[i] ?? 0;
-    if (na !== nb) return na - nb;
-  }
-  return 0;
+  latest?: string;
+  url?: string;
+  error?: string;
 }
 
 export class VersionChecker {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private timeoutId: ReturnType<typeof setTimeout> | null = null;
-  private latestInfo: VersionInfo | null = null;
   private mainWindow: BrowserWindow;
+  private updateInfo: UpdateInfo;
+  private supportsAutoUpdate: boolean;
+  private versionStore = new Store({ name: 'tmax-version-check' });
 
   constructor(mainWindow: BrowserWindow) {
     this.mainWindow = mainWindow;
+    this.updateInfo = {
+      status: 'idle',
+      current: app.getVersion(),
+    };
+    // Auto-update works on packaged Windows/macOS builds only
+    this.supportsAutoUpdate = app.isPackaged &&
+      (process.platform === 'win32' || process.platform === 'darwin');
   }
 
   start(): void {
-    this.timeoutId = setTimeout(() => {
-      this.check();
-      this.intervalId = setInterval(() => this.check(), CHECK_INTERVAL_MS);
-    }, INITIAL_DELAY_MS);
+    if (this.supportsAutoUpdate) {
+      this.setupAutoUpdater();
+    } else {
+      this.setupGitHubPolling();
+    }
   }
 
   stop(): void {
@@ -47,16 +50,96 @@ export class VersionChecker {
     if (this.intervalId) clearInterval(this.intervalId);
   }
 
-  getUpdateInfo(): VersionInfo | null {
-    return this.latestInfo;
+  getUpdateInfo(): UpdateInfo {
+    return this.updateInfo;
   }
 
-  async checkNow(): Promise<VersionInfo | null> {
-    await this.check();
-    return this.latestInfo;
+  checkNow(): void {
+    if (this.supportsAutoUpdate) {
+      autoUpdater.checkForUpdates();
+    } else {
+      this.checkGitHub();
+    }
   }
 
-  private async check(): Promise<void> {
+  restartAndUpdate(): void {
+    if (this.supportsAutoUpdate && this.updateInfo.status === 'downloaded') {
+      autoUpdater.quitAndInstall();
+    }
+  }
+
+  private setupAutoUpdater(): void {
+    const feedURL = `${UPDATE_SERVER}/${GITHUB_REPO}/${process.platform}-${process.arch}/${app.getVersion()}`;
+
+    try {
+      autoUpdater.setFeedURL({ url: feedURL });
+    } catch (err) {
+      console.error('Failed to set auto-update feed URL:', err);
+      this.supportsAutoUpdate = false;
+      this.setupGitHubPolling();
+      return;
+    }
+
+    autoUpdater.on('checking-for-update', () => {
+      this.setStatus('checking');
+    });
+
+    autoUpdater.on('update-available', () => {
+      this.setStatus('downloading');
+    });
+
+    autoUpdater.on('update-not-available', () => {
+      this.setStatus('idle');
+    });
+
+    autoUpdater.on('update-downloaded', (_event, _releaseNotes, releaseName) => {
+      const version = (releaseName || '').replace(/^v/, '') || undefined;
+      this.updateInfo = {
+        ...this.updateInfo,
+        status: 'downloaded',
+        latest: version,
+      };
+      this.broadcastUpdate();
+
+      // Show native notification once
+      const lastNotified = this.versionStore.get('lastNotifiedVersion', '') as string;
+      if (version && lastNotified !== version && Notification.isSupported()) {
+        const notification = new Notification({
+          title: 'tmax Update Ready',
+          body: `Version ${version} downloaded. Restart to apply.`,
+        });
+        notification.show();
+        this.versionStore.set('lastNotifiedVersion', version);
+      }
+    });
+
+    autoUpdater.on('error', (err: Error) => {
+      console.error('Auto-update error:', err.message);
+      this.updateInfo = {
+        ...this.updateInfo,
+        status: 'error',
+        error: err.message,
+      };
+      this.broadcastUpdate();
+      // Fall back to GitHub API to at least show the available version
+      this.checkGitHub();
+    });
+
+    // Start checking after initial delay
+    this.timeoutId = setTimeout(() => {
+      autoUpdater.checkForUpdates();
+      this.intervalId = setInterval(() => autoUpdater.checkForUpdates(), CHECK_INTERVAL_MS);
+    }, INITIAL_DELAY_MS);
+  }
+
+  private setupGitHubPolling(): void {
+    this.timeoutId = setTimeout(() => {
+      this.checkGitHub();
+      this.intervalId = setInterval(() => this.checkGitHub(), CHECK_INTERVAL_MS);
+    }, INITIAL_DELAY_MS);
+  }
+
+  private async checkGitHub(): Promise<void> {
     try {
       const res = await fetch(GITHUB_RELEASES_URL, {
         headers: { 'User-Agent': 'tmax-update-checker' },
@@ -68,34 +151,51 @@ export class VersionChecker {
       const htmlUrl: string = data.html_url;
       const currentVersion = app.getVersion();
 
-      if (compareVersions(tagName, currentVersion) > 0) {
+      if (this.compareVersions(tagName, currentVersion) > 0) {
         const latestClean = tagName.replace(/^v/, '');
-        this.latestInfo = {
+        this.updateInfo = {
+          status: 'available',
           current: currentVersion,
           latest: latestClean,
           url: htmlUrl,
         };
+        this.broadcastUpdate();
 
         // Show native notification once per new version
-        const lastNotified = versionStore.get('lastNotifiedVersion', '') as string;
+        const lastNotified = this.versionStore.get('lastNotifiedVersion', '') as string;
         if (lastNotified !== latestClean && Notification.isSupported()) {
           const notification = new Notification({
             title: 'tmax Update Available',
             body: `Version ${latestClean} is available (you have ${currentVersion})`,
           });
           notification.show();
-          versionStore.set('lastNotifiedVersion', latestClean);
+          this.versionStore.set('lastNotifiedVersion', latestClean);
         }
-
-        // Push to renderer
-        if (this.mainWindow && !this.mainWindow.isDestroyed()) {
-          this.mainWindow.webContents.send(IPC.VERSION_NEW_AVAILABLE, this.latestInfo);
-        }
-      } else {
-        this.latestInfo = null;
       }
     } catch {
       // Silently ignore network errors
     }
+  }
+
+  private setStatus(status: UpdateStatus): void {
+    this.updateInfo = { ...this.updateInfo, status };
+    this.broadcastUpdate();
+  }
+
+  private broadcastUpdate(): void {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send(IPC.VERSION_UPDATE_STATUS, this.updateInfo);
+    }
+  }
+
+  private compareVersions(a: string, b: string): number {
+    const pa = a.replace(/^v/, '').split('.').map(Number);
+    const pb = b.replace(/^v/, '').split('.').map(Number);
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+      const na = pa[i] ?? 0;
+      const nb = pb[i] ?? 0;
+      if (na !== nb) return na - nb;
+    }
+    return 0;
   }
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -23,9 +23,10 @@ export interface TerminalAPI {
   clipboardHasImage(): boolean;
   clipboardSaveImage(): Promise<string>;
   getAppVersion(): Promise<string>;
-  getVersionUpdate(): Promise<{ current: string; latest: string; url: string } | null>;
-  checkForUpdates(): Promise<{ current: string; latest: string; url: string } | null>;
-  onNewVersionAvailable(cb: (info: { current: string; latest: string; url: string }) => void): () => void;
+  getVersionUpdate(): Promise<{ status: string; current: string; latest?: string; url?: string; error?: string } | null>;
+  checkForUpdates(): void;
+  restartAndUpdate(): void;
+  onUpdateStatusChanged(cb: (info: { status: string; current: string; latest?: string; url?: string; error?: string }) => void): () => void;
 }
 
 const terminalAPI: TerminalAPI = {
@@ -249,16 +250,20 @@ const terminalAPI: TerminalAPI = {
   },
 
   checkForUpdates() {
-    return ipcRenderer.invoke(IPC.VERSION_CHECK_NOW);
+    ipcRenderer.send(IPC.VERSION_CHECK_NOW);
   },
 
-  onNewVersionAvailable(cb: (info: { current: string; latest: string; url: string }) => void): () => void {
-    const listener = (_event: Electron.IpcRendererEvent, info: { current: string; latest: string; url: string }) => {
+  restartAndUpdate() {
+    ipcRenderer.send(IPC.VERSION_RESTART_AND_UPDATE);
+  },
+
+  onUpdateStatusChanged(cb: (info: { status: string; current: string; latest?: string; url?: string; error?: string }) => void): () => void {
+    const listener = (_event: Electron.IpcRendererEvent, info: { status: string; current: string; latest?: string; url?: string; error?: string }) => {
       cb(info);
     };
-    ipcRenderer.on(IPC.VERSION_NEW_AVAILABLE, listener);
+    ipcRenderer.on(IPC.VERSION_UPDATE_STATUS, listener);
     return () => {
-      ipcRenderer.removeListener(IPC.VERSION_NEW_AVAILABLE, listener);
+      ipcRenderer.removeListener(IPC.VERSION_UPDATE_STATUS, listener);
     };
   },
 

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -4,14 +4,14 @@ import { getLeafOrder } from '../state/terminal-store';
 
 const StatusBar: React.FC = () => {
   const [appVersion, setAppVersion] = useState<string>('');
-  const [updateInfo, setUpdateInfo] = useState<{ current: string; latest: string; url: string } | null>(null);
+  const [updateInfo, setUpdateInfo] = useState<{ status: string; current: string; latest?: string; url?: string } | null>(null);
 
   useEffect(() => {
     window.terminalAPI.getAppVersion().then(setAppVersion);
     window.terminalAPI.getVersionUpdate().then((info) => {
       if (info) setUpdateInfo(info);
     });
-    const cleanup = window.terminalAPI.onNewVersionAvailable((info) => {
+    const cleanup = window.terminalAPI.onUpdateStatusChanged((info) => {
       setUpdateInfo(info);
     });
     return cleanup;
@@ -80,7 +80,22 @@ const StatusBar: React.FC = () => {
           {floatingCount > 0 ? ` (${tiledCount} tiled, ${floatingCount} floating)` : ''}
         </span>
         <span className="status-dim">{Math.round((fontSize / (config?.terminal?.fontSize ?? 14)) * 100)}%</span>
-        {updateInfo ? (
+        {updateInfo && updateInfo.status === 'downloading' ? (
+          <span
+            className="status-update-downloading"
+            title={`Downloading update${updateInfo.latest ? ` v${updateInfo.latest}` : ''}...`}
+          >
+            ⟳ Updating{updateInfo.latest ? ` to v${updateInfo.latest}` : ''}
+          </span>
+        ) : updateInfo && updateInfo.status === 'downloaded' ? (
+          <span
+            className="status-update-ready"
+            onClick={() => window.terminalAPI.restartAndUpdate()}
+            title="Click to restart and apply update"
+          >
+            v{appVersion} → v{updateInfo.latest} ↻
+          </span>
+        ) : updateInfo && updateInfo.status === 'available' && updateInfo.url ? (
           <span
             className="status-update-available"
             onClick={() => window.open(updateInfo.url, '_blank')}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -977,6 +977,31 @@ body,
   text-decoration: underline;
 }
 
+.status-update-downloading {
+  color: #e8a838;
+  font-weight: 600;
+  animation: pulse-update 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-update {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.status-update-ready {
+  color: #4ec957;
+  cursor: pointer;
+  font-weight: 600;
+  background: rgba(78, 201, 87, 0.1);
+  padding: 0 6px;
+  border-radius: 3px;
+}
+
+.status-update-ready:hover {
+  background: rgba(78, 201, 87, 0.2);
+  text-decoration: underline;
+}
+
 .status-cwd {
   color: var(--text-secondary);
   cursor: pointer;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -33,10 +33,11 @@ export const IPC = {
   CLAUDE_CODE_START_WATCHING: 'claude-code:startWatching',
   CLAUDE_CODE_STOP_WATCHING: 'claude-code:stopWatching',
   CLAUDE_CODE_GET_PROMPTS: 'claude-code:getPrompts',
-  VERSION_NEW_AVAILABLE: 'version:newAvailable',
+  VERSION_UPDATE_STATUS: 'version:updateStatus',
   VERSION_GET_UPDATE: 'version:getUpdate',
   VERSION_CHECK_NOW: 'version:checkNow',
   VERSION_GET_APP_VERSION: 'version:getAppVersion',
+  VERSION_RESTART_AND_UPDATE: 'version:restartAndUpdate',
   CLIPBOARD_SAVE_IMAGE: 'clipboard:saveImage',
 } as const;
 


### PR DESCRIPTION
## Summary
Adds auto-update support so users don't have to manually download new versions from GitHub. Closes #6.

## What Changed (6 files, +210/-54 lines)

| File | Change |
|------|--------|
| `src/main/version-checker.ts` | Complete rewrite: uses Electron's `autoUpdater` with `update.electronjs.org` on Win/Mac, falls back to GitHub API polling on Linux/dev |
| `src/main/main.ts` | Add Squirrel.Windows lifecycle handling, update IPC handlers for new channels |
| `src/shared/ipc-channels.ts` | Add `VERSION_UPDATE_STATUS` and `VERSION_RESTART_AND_UPDATE` channels |
| `src/preload/preload.ts` | Add `onUpdateStatusChanged()` and `restartAndUpdate()` APIs |
| `src/renderer/components/StatusBar.tsx` | Handle downloading, downloaded, and available states with distinct UI |
| `src/renderer/styles/global.css` | Add styles for downloading (pulsing amber) and ready-to-restart (green highlight) states |

## How It Works

### On Windows/macOS (packaged builds)
1. `autoUpdater` checks `update.electronjs.org` every hour
2. When update found -> downloads in background
3. StatusBar shows **⟳ Updating to vX.X.X** (amber, pulsing)
4. When download complete -> StatusBar shows **v1.3.7 -> v1.3.8 ↻** (green, clickable)
5. User clicks -> app restarts and applies the update

### On Linux / dev mode
Falls back to current behavior: polls GitHub Releases API, shows version link that opens GitHub.

## Platform Support

| Platform | Auto-Update | Notes |
|----------|-------------|-------|
| Windows | ✅ Full | Squirrel.Windows (already configured via MakerSquirrel) |
| macOS | ⚠️ Requires code signing | Falls back to GitHub link without signing |
| Linux | ❌ | Keeps current manual download behavior |

## Testing
- TypeScript check: 24 errors before and after (all pre-existing, none from this change)
- Manual test: app launches, Version checker starts, StatusBar renders correctly
- Dev mode correctly falls back to GitHub polling (not auto-update)