### PR TITLE
fix: use shifted key character in Ctrl+Shift+/ default binding

### DIFF
--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -63,7 +63,7 @@ const CommandPalette: React.FC = () => {
       { id: 'dirPicker', label: 'Go to Directory (Favorites & Recent)', shortcut: 'Ctrl+Shift+D', action: () => store().toggleDirPicker() },
       { id: 'colorizeAllTabs', label: 'Toggle Tab Colors', shortcut: 'Ctrl+Shift+O', action: () => store().colorizeAllTabs() },
       { id: 'toggleTabBar', label: 'Toggle Tab Bar: Top / Left', action: () => store().toggleTabBarPosition() },
-      { id: 'shortcuts', label: 'Show Keyboard Shortcuts', shortcut: 'Ctrl+Shift+/', action: () => store().toggleShortcuts() },
+      { id: 'shortcuts', label: 'Show Keyboard Shortcuts', shortcut: 'Ctrl+Shift+?', action: () => store().toggleShortcuts() },
       { id: 'settings', label: 'Open Settings', shortcut: 'Ctrl+,', action: () => store().toggleSettings() },
       { id: 'checkForUpdates', label: 'Check for Updates', action: () => {
         window.terminalAPI.checkForUpdates();

--- a/src/renderer/hooks/useKeybindings.ts
+++ b/src/renderer/hooks/useKeybindings.ts
@@ -11,7 +11,7 @@ interface KeyCombo {
 
 function parseKeyCombo(combo: string): KeyCombo {
   // Handle special cases: "Ctrl+=" ends with "+" then "=" which splits oddly
-  // Also "Ctrl+-" and "Ctrl+Shift+/" need care
+  // Also "Ctrl+-" and "Ctrl+Shift+?" need care
   const ctrlKey = /\bctrl\b/i.test(combo);
   const shiftKey = /\bshift\b/i.test(combo);
   const altKey = /\balt\b/i.test(combo);
@@ -57,7 +57,7 @@ const DEFAULT_BINDINGS: Record<string, string> = {
   'Ctrl+Shift+E': 'equalizeLayout',
   'Ctrl+,': 'openSettings',
   'Ctrl+Shift+R': 'renameTerminal',
-  'Ctrl+Shift+/': 'showShortcuts',
+  'Ctrl+Shift+?': 'showShortcuts',
   'Ctrl+Shift+G': 'switchTerminal',
   'Ctrl+Shift+D': 'dirPicker',
   'Ctrl+Shift+P': 'commandPalette',


### PR DESCRIPTION
## Summary

Fixes the `Ctrl+Shift+/` keybinding for "Show Keyboard Shortcuts" which never matched because the browser reports `?` (the shifted character) as `event.key` when pressing `Shift+/` on standard keyboards. Changed the default binding and display label to `Ctrl+Shift+?` to align with what the Settings key recorder already produces.

## Changes (2 files, +3/-3 lines)

| File | Change |
|------|--------|
| `src/renderer/hooks/useKeybindings.ts` | Update `DEFAULT_BINDINGS` from `Ctrl+Shift+/` to `Ctrl+Shift+?`; update comment |
| `src/renderer/components/CommandPalette.tsx` | Update shortcut display label to `Ctrl+Shift+?` |

## How it works

When a user presses `Ctrl+Shift+/`, the browser fires a `keydown` event with `event.key === '?'` (because `Shift+/` produces `?`). The old default binding `Ctrl+Shift+/` was parsed to look for key `'/'`, which never matched. The fix changes the binding string to `Ctrl+Shift+?` so `parseKeyCombo` extracts `'?'` and `matchesCombo` correctly compares it against `event.key`.

## Testing

- Verified `parseKeyCombo('Ctrl+Shift+?')` correctly extracts `{ ctrlKey: true, shiftKey: true, key: '?' }`
- Verified `matchesCombo` compares `event.key.toLowerCase()` (`'?'`) against the parsed key (`'?'`) — matches correctly
- Confirmed the Settings recorder already produces `Ctrl+Shift+?` when recording this shortcut, so round-trip is consistent

🤖 Generated with [Claude Code](https://claude.ai/code)