### PR TITLE
fix: use capture phase for ShortcutsHelp escape handler

### DIFF
--- a/src/renderer/components/ShortcutsHelp.tsx
+++ b/src/renderer/components/ShortcutsHelp.tsx
@@ -40,10 +40,13 @@ const shortcuts = [
 const ShortcutsHelp: React.FC<ShortcutsHelpProps> = ({ onClose }) => {
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
     };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
+    document.addEventListener('keydown', handleKey, true);
+    return () => document.removeEventListener('keydown', handleKey, true);
   }, [onClose]);
 
   return (


### PR DESCRIPTION
## Summary

- Fix Escape key not closing the ShortcutsHelp dialog when a terminal has focus

## Changes

Switch the keydown event listener in `ShortcutsHelp.tsx` from **bubbling phase** to **capture phase**, matching the pattern used by `Settings.tsx` and `TabContextMenu.tsx`.

- Add `true` (capture) to `addEventListener` / `removeEventListener`
- Add `e.stopPropagation()` to prevent xterm.js from also processing Escape as `\x1b`

## How it works

xterm.js's textarea retains focus when the dialog opens and consumes keydown events during bubbling. Capture-phase handlers on `document` fire **before** the event reaches xterm, so the overlay intercepts Escape first.

## Testing

- Open tmax → `Ctrl+Shift+?` → press `Escape` → dialog closes
- Verify `Settings` (`Ctrl+,` → Escape) and `TabContextMenu` (right-click tab → Escape) still work
- Verify terminal still receives Escape normally when no overlay is open