### PR TITLE
fix: prevent pane title from overlapping terminal content

### DIFF
--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -361,6 +361,8 @@ body,
   border: 1px solid var(--border-color);
   overflow: hidden;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .terminal-panel.focused {
@@ -369,10 +371,7 @@ body,
 }
 
 .terminal-pane-title {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  flex-shrink: 0;
   z-index: 5;
   font-size: 11px;
   font-weight: 600;
@@ -524,7 +523,8 @@ body,
 
 .terminal-panel .xterm-container {
   width: 100%;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 
 .terminal-panel .xterm-container .xterm {


### PR DESCRIPTION
## Bug Fix: Pane title overlapping terminal content

### Problem
The session name label (e.g., **pwsh**, **cmd.exe**) displayed above each terminal pane was overlapping the first row of terminal content. The label used `position: absolute; top: 0` which placed it on top of the xterm.js terminal without reserving any layout space.

### Fix
Changed the terminal panel layout from a simple positioned container to a **flexbox column layout**, making the title a real layout participant:

1. **`.terminal-panel`** — Added `display: flex; flex-direction: column` to establish vertical stacking
2. **`.terminal-pane-title`** — Replaced `position: absolute; top: 0; left: 0; right: 0` with `flex-shrink: 0` so it takes real space in the layout flow
3. **`.xterm-container`** — Changed from `height: 100%` to `flex: 1; min-height: 0` to fill remaining space (`min-height: 0` is critical to prevent xterm.js canvas overflow)

### Why this approach
- Same pattern used by VS Code's own xterm.js integration
- Only 2 of 6 child elements participate in flex layout; the other 4 (search bar, diagnostics overlay, refocus button, color overlay) use `position: absolute` and are completely unaffected
- FitAddon works correctly with flex containers
- Validated by architectural review and xterm.js compatibility research

### Files changed
- `src/renderer/styles/global.css` — 3 CSS rule changes (no TSX changes needed)