### PR TITLE
fix: enforce minimum pane size to prevent text smudging

### DIFF
--- a/src/renderer/components/SplitResizer.tsx
+++ b/src/renderer/components/SplitResizer.tsx
@@ -2,6 +2,9 @@ import React, { useCallback, useRef, useState } from 'react';
 import { useTerminalStore } from '../state/terminal-store';
 import type { SplitDirection } from '../state/types';
 
+/** Minimum pane size in pixels to prevent unusable narrow terminals */
+const MIN_PANE_PX = 120;
+
 interface SplitResizerProps {
   splitNodeId: string;
   direction: SplitDirection;
@@ -48,7 +51,12 @@ const SplitResizer: React.FC<SplitResizerProps> = ({
         const deltaPx = currentPos - startPosRef.current;
         const deltaRatio = deltaPx / parentSizeRef.current;
         const newRatio = startRatioRef.current + deltaRatio;
-        useTerminalStore.getState().setSplitRatio(splitNodeId, newRatio);
+        // Pixel-aware clamp: keep each pane ≥ MIN_PANE_PX
+        const minRatio = parentSizeRef.current > 0
+          ? MIN_PANE_PX / parentSizeRef.current
+          : 0.1;
+        const clamped = Math.max(minRatio, Math.min(1 - minRatio, newRatio));
+        useTerminalStore.getState().setSplitRatio(splitNodeId, clamped);
       };
 
       const handleMouseUp = () => {

--- a/src/renderer/components/TilingLayout.tsx
+++ b/src/renderer/components/TilingLayout.tsx
@@ -33,8 +33,8 @@ const TilingNode: React.FC<TilingNodeProps> = ({ node }) => {
           flexShrink: 0,
           overflow: 'hidden',
           display: 'flex',
-          minWidth: isHorizontal ? 0 : undefined,
-          minHeight: !isHorizontal ? 0 : undefined,
+          minWidth: isHorizontal ? 120 : undefined,
+          minHeight: !isHorizontal ? 60 : undefined,
         }}
       >
         <TilingNode node={splitNode.first} />
@@ -50,8 +50,8 @@ const TilingNode: React.FC<TilingNodeProps> = ({ node }) => {
           flexShrink: 0,
           overflow: 'hidden',
           display: 'flex',
-          minWidth: isHorizontal ? 0 : undefined,
-          minHeight: !isHorizontal ? 0 : undefined,
+          minWidth: isHorizontal ? 120 : undefined,
+          minHeight: !isHorizontal ? 60 : undefined,
         }}
       >
         <TilingNode node={splitNode.second} />


### PR DESCRIPTION
## Bug Fix: Narrow panes cause text smudging

Closes #12

### Problem
When panes are dragged very narrow or result from nested splits, text wraps after 1-3 characters creating an unreadable smudged appearance. The existing ratio clamp (\[0.1, 0.9]\) is relative to the **parent pane** — nested splits compound, allowing sub-10px panes where xterm.js renders at \cols=1\.

### Fix (two layers)

**1. Pixel-aware drag clamping** (\SplitResizer.tsx\)
- Added \MIN_PANE_PX = 120\ constant
- During drag, compute the minimum ratio from actual parent pixel size: \minRatio = 120 / parentSize\
- Clamp ratio to \[minRatio, 1 - minRatio]\ so neither pane can go below 120px

**2. CSS floor** (\TilingLayout.tsx\)
- Changed \minWidth: 0\ → \minWidth: 120\ for horizontal splits
- Changed \minHeight: 0\ → \minHeight: 60\ for vertical splits
- Acts as a last-resort guard for edge cases (e.g., window resize making existing ratios produce too-small panes)

### Why 120px?
At typical terminal font sizes (~8px/char for Cascadia Code at 14pt), 120px ≈ 15 characters — enough for a usable prompt and short commands.

### Files changed
- \src/renderer/components/SplitResizer.tsx\ — pixel-aware ratio clamping + MIN_PANE_PX constant
- \src/renderer/components/TilingLayout.tsx\ — CSS minWidth/minHeight on flex children