### PR TITLE
fix: inject DEC focus sequences on pane switch to prevent input loss

### DIFF
--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -95,6 +95,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
   const isFocused = focusedTerminalId === terminalId;
 
   const handleFocus = useCallback(() => {
+    const prevFocused = useTerminalStore.getState().focusedTerminalId;
     useTerminalStore.getState().setFocus(terminalId);
     diagRef.current.focusEventCount++;
     diagRef.current.lastFocusTime = Date.now();
@@ -104,6 +105,17 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
     try {
       terminalRef.current?.focus();
     } catch { /* terminal may be disposed */ }
+    // Ensure DEC focus reporting reaches the PTY even if xterm.js lost
+    // its internal focus-reporting state (e.g. after a pane split/resize).
+    // Without this, Copilot CLI stays in isFocused=false and drops input.
+    if (prevFocused !== terminalId) {
+      if (prevFocused) {
+        window.terminalAPI.writePty(prevFocused, '\x1b[O');
+        window.terminalAPI.diagLog('renderer:focus-inject-out', { terminalId: prevFocused });
+      }
+      window.terminalAPI.writePty(terminalId, '\x1b[I');
+      window.terminalAPI.diagLog('renderer:focus-inject-in', { terminalId });
+    }
   }, [terminalId]);
 
   useEffect(() => {


### PR DESCRIPTION
:robot: _AI Generated_

## Problem

After splitting a pane, xterm.js can lose its internal DEC focus reporting state (`\x1b[?1004h]`), causing it to stop generating `\x1b[I`/`\x1b[O` sequences. Copilot CLI then permanently believes it is unfocused and silently drops all keyboard input. The cursor also becomes misaligned due to the rapid resize during the split.

## Evidence from tmax-diag.log

- Before the split: 44 `focus-gained` events, 15 matching `\x1b[I]` writes — all 15 occurred before the split.
- After the split: 29 `focus-gained` events, **zero** `\x1b[I` writes.
- Exact transition: `pty:created` at 16:55:02.396, followed by resize 79->38 rows and final `\x1b[O` at 16:55:02.421. No `\x1b[I` ever sent again.

## Fix

Explicitly write `\x1b[I` (focus-in) to the PTY when switching TO a terminal, and `\x1b[O` (focus-out) to the terminal being left. This mirrors the existing 'Unfreeze Terminal' context menu item but happens automatically on every pane switch.

12 lines changed in one file.