### PR TITLE
feat: pane hint overlay for quick terminal switching (Ctrl+Shift+G)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import TilingLayout from './components/TilingLayout';
 import FloatingLayer from './components/FloatingLayer';
 import DropZoneOverlay from './components/DropZoneOverlay';
 import TerminalSwitcher from './components/TerminalSwitcher';
+import PaneHintOverlay from './components/PaneHintOverlay';
 import StatusBar from './components/StatusBar';
 import ShortcutsHelp from './components/ShortcutsHelp';
 import Settings from './components/Settings';
@@ -171,6 +172,7 @@ const App: React.FC = () => {
         {tabBarPosition === 'bottom' && <TabBar />}
         <StatusBar />
         <TerminalSwitcher />
+        <PaneHintOverlay />
         <CommandPalette />
         <Settings />
         {showShortcuts && (

--- a/src/renderer/components/PaneHintOverlay.tsx
+++ b/src/renderer/components/PaneHintOverlay.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { useTerminalStore } from '../state/terminal-store';
+import type { LayoutNode } from '../state/types';
+
+const HINT_KEYS = 'asdfghjklqwertyuiopzxcvbnm';
+
+function collectLeafIds(node: LayoutNode | null): string[] {
+  if (!node) return [];
+  if (node.kind === 'leaf') return [node.terminalId];
+  return [...collectLeafIds(node.first), ...collectLeafIds(node.second)];
+}
+
+const PaneHintOverlay: React.FC = () => {
+  const show = useTerminalStore((s) => s.showPaneHints);
+  const tilingRoot = useTerminalStore((s) => s.layout.tilingRoot);
+  const [hints, setHints] = useState<{ key: string; terminalId: string; rect: DOMRect }[]>([]);
+
+  // Build hint positions from DOM once overlay becomes visible
+  useEffect(() => {
+    if (!show) {
+      setHints([]);
+      return;
+    }
+
+    const leafIds = collectLeafIds(tilingRoot);
+    const computed: typeof hints = [];
+
+    for (let i = 0; i < leafIds.length && i < HINT_KEYS.length; i++) {
+      const terminalId = leafIds[i];
+      // Find the .tiling-leaf element that contains this terminal's xterm-container
+      const xtermEl = document.querySelector(
+        `.terminal-panel[data-terminal-id="${terminalId}"]`
+      );
+      const leafEl = xtermEl?.closest('.tiling-leaf');
+      if (leafEl) {
+        computed.push({
+          key: HINT_KEYS[i],
+          terminalId,
+          rect: leafEl.getBoundingClientRect(),
+        });
+      }
+    }
+
+    setHints(computed);
+  }, [show, tilingRoot]);
+
+  const dismiss = useCallback(() => {
+    useTerminalStore.getState().togglePaneHints();
+  }, []);
+
+  const selectPane = useCallback((terminalId: string) => {
+    useTerminalStore.getState().setFocus(terminalId);
+    useTerminalStore.getState().togglePaneHints();
+  }, []);
+
+  // Listen for key presses while hints are visible
+  useEffect(() => {
+    if (!show || hints.length === 0) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === 'Escape') {
+        dismiss();
+        return;
+      }
+
+      const pressed = e.key.toLowerCase();
+      const match = hints.find((h) => h.key === pressed);
+      if (match) {
+        selectPane(match.terminalId);
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [show, hints, dismiss, selectPane]);
+
+  if (!show || hints.length === 0) return null;
+
+  return (
+    <div className="pane-hint-backdrop" onClick={dismiss}>
+      {hints.map((hint) => (
+        <div
+          key={hint.terminalId}
+          className="pane-hint-label"
+          style={{
+            left: hint.rect.left + hint.rect.width / 2,
+            top: hint.rect.top + hint.rect.height / 2,
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            selectPane(hint.terminalId);
+          }}
+        >
+          {hint.key}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PaneHintOverlay;

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -549,6 +549,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
   return (
     <div
       className={className}
+      data-terminal-id={terminalId}
       onMouseDownCapture={(e) => {
         if (!isFocused) {
           // This click is a pane-switch click, not a TUI interaction.

--- a/src/renderer/hooks/useKeybindings.ts
+++ b/src/renderer/hooks/useKeybindings.ts
@@ -59,6 +59,7 @@ const DEFAULT_BINDINGS: Record<string, string> = {
   'Ctrl+Shift+R': 'renameTerminal',
   'Ctrl+Shift+?': 'showShortcuts',
   'Ctrl+Shift+G': 'switchTerminal',
+  'Ctrl+Shift+J': 'switchTerminalList',
   'Ctrl+Shift+D': 'dirPicker',
   'Ctrl+Shift+P': 'commandPalette',
   'Ctrl+Tab': 'focusNext',
@@ -179,6 +180,9 @@ function dispatchAction(action: string): void {
       }
       break;
     case 'switchTerminal':
+      store.togglePaneHints();
+      break;
+    case 'switchTerminalList':
       store.toggleSwitcher();
       break;
     case 'renameTerminal':

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -320,6 +320,7 @@ interface TerminalStore {
   draggedTerminalId: TerminalId | null;
   nextZIndex: number;
   showSwitcher: boolean;
+  showPaneHints: boolean;
   showShortcuts: boolean;
   showCommandPalette: boolean;
   showSettings: boolean;
@@ -372,6 +373,7 @@ interface TerminalStore {
   colorizeAllTabs: () => void;
   setDragging: (isDragging: boolean, terminalId?: TerminalId) => void;
   toggleSwitcher: () => void;
+  togglePaneHints: () => void;
   toggleShortcuts: () => void;
   toggleCommandPalette: () => void;
   toggleSettings: () => void;
@@ -435,6 +437,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   draggedTerminalId: null,
   nextZIndex: 100,
   showSwitcher: false,
+  showPaneHints: false,
   showShortcuts: false,
   showCommandPalette: false,
   showSettings: false,
@@ -1122,6 +1125,10 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
 
   toggleSwitcher: () => {
     set((state) => ({ showSwitcher: !state.showSwitcher }));
+  },
+
+  togglePaneHints: () => {
+    set((state) => ({ showPaneHints: !state.showPaneHints }));
   },
 
   toggleShortcuts: () => {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1442,6 +1442,40 @@ body,
   font-size: 13px;
 }
 
+/* ===== Pane Hint Overlay ===== */
+.pane-hint-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.pane-hint-label {
+  position: fixed;
+  transform: translate(-50%, -50%);
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: var(--focus-border, #89b4fa);
+  color: var(--bg-primary, #1e1e2e);
+  font-size: 24px;
+  font-weight: 700;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  text-transform: uppercase;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  pointer-events: auto;
+  cursor: pointer;
+  user-select: none;
+}
+
+.pane-hint-label:hover {
+  transform: translate(-50%, -50%) scale(1.1);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.6);
+}
+
 /* ===== Dir Side Panel ===== */
 .dir-panel {
   position: relative;


### PR DESCRIPTION
## Summary

Replaces the dropdown terminal switcher (Ctrl+Shift+G) with a pane hint overlay, similar to tmux's `display-panes` or vim-easymotion.

**Before**: A searchable dropdown list of all terminals.
**After**: Each visible tiled pane gets a letter badge (a, s, d, f, ...) overlaid on it. Press a letter to jump to that pane. Press Escape to dismiss.

The previous list-based switcher is preserved on **Ctrl+Shift+J** for cases where you need to jump to terminals on other tabs or dormant terminals.

## Changes

- **New component**: `PaneHintOverlay.tsx` renders letter badges positioned at the center of each tiled pane using DOM measurements
- **Store**: Added `showPaneHints` state and `togglePaneHints` action
- **Keybindings**: `Ctrl+Shift+G` now triggers pane hints; old list switcher moved to `Ctrl+Shift+J` (`switchTerminalList` action)
- **TerminalPanel**: Added `data-terminal-id` attribute for DOM-based pane lookup
- **CSS**: Styled hint badges with the theme accent color

## How it works

1. Walks the tiling layout tree to collect visible leaf terminal IDs
2. Assigns a letter from the home row outward (a, s, d, f, g, h, j, k, l, ...)
3. Queries the DOM to find each pane's bounding rect via `data-terminal-id`
4. Renders positioned hint labels; captures the next keypress to select or dismiss