### PR TITLE
fix: restore hidden-tab-bar rename input

### DIFF
--- a/src/renderer/components/FloatingRenameInput.tsx
+++ b/src/renderer/components/FloatingRenameInput.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useTerminalStore } from '../state/terminal-store';
+
+const FloatingRenameInput: React.FC = () => {
+  const renamingTerminalId = useTerminalStore((s) => s.renamingTerminalId);
+  const hideTabTitles = useTerminalStore((s) => s.hideTabTitles);
+  const terminalTitle = useTerminalStore((s) => (
+    renamingTerminalId ? s.terminals.get(renamingTerminalId)?.title ?? '' : ''
+  ));
+  const [renameValue, setRenameValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const shouldShow = hideTabTitles && renamingTerminalId !== null;
+
+  useEffect(() => {
+    if (!shouldShow) return;
+
+    setRenameValue(terminalTitle);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  }, [shouldShow, terminalTitle]);
+
+  if (!shouldShow || !renamingTerminalId) return null;
+
+  const handleCancel = () => {
+    useTerminalStore.getState().startRenaming(null);
+  };
+
+  const handleSubmit = () => {
+    if (renameValue.trim()) {
+      useTerminalStore.getState().renameTerminal(renamingTerminalId, renameValue.trim(), true);
+    }
+    useTerminalStore.getState().startRenaming(null);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    if (e.key === 'Enter') handleSubmit();
+    if (e.key === 'Escape') handleCancel();
+  };
+
+  return (
+    <div className="floating-rename-overlay">
+      <div className="floating-rename-box">
+        <input
+          ref={inputRef}
+          className="rename-input"
+          type="text"
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleSubmit}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default FloatingRenameInput;

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -377,7 +377,7 @@ interface TerminalStore {
   focusNext: () => void;
   focusPrev: () => void;
   focusDirection: (dir: 'left' | 'right' | 'up' | 'down') => void;
-  renameTerminal: (id: TerminalId, title: string) => void;
+  renameTerminal: (id: TerminalId, title: string, custom?: boolean) => void;
   setTabColor: (id: TerminalId, color: string | undefined) => void;
   colorizeAllTabs: () => void;
   setDragging: (isDragging: boolean, terminalId?: TerminalId) => void;


### PR DESCRIPTION
- App.tsx imported/rendered FloatingRenameInput but the component file was missing, which broke both npm start and npm run build in the renderer bundle.
- This PR adds the missing floating rename component for hidden-tab-bar mode and aligns the renameTerminal store typing with existing callers that pass the custom-title flag.
- Validation: npm start no longer hits the missing-import error and npm run build succeeds.