### PR TITLE
feat: Windows 11 Mica & Acrylic background transparency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmax",
-  "version": "1.3.2",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmax",
-      "version": "1.3.2",
+      "version": "1.4.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/config-store.ts
+++ b/src/main/config-store.ts
@@ -43,6 +43,8 @@ export interface TerminalDefaults {
   scrollback: number;
 }
 
+export type BackgroundMaterial = 'none' | 'auto' | 'mica' | 'acrylic' | 'tabbed';
+
 export interface AppConfig {
   shells: ShellProfile[];
   defaultShellId: string;
@@ -52,6 +54,8 @@ export interface AppConfig {
   copilotCommand?: string;
   claudeCodeCommand?: string;
   tabBarPosition?: 'top' | 'bottom' | 'left' | 'right';
+  backgroundMaterial?: BackgroundMaterial;
+  backgroundOpacity?: number; // 0.0–1.0, default 0.8
 }
 
 function findPwsh(): string | null {
@@ -160,6 +164,8 @@ const defaultConfig: AppConfig = {
   },
   copilotCommand: 'agency copilot',
   claudeCodeCommand: 'claude',
+  backgroundMaterial: 'none',
+  backgroundOpacity: 0.8,
 };
 
 export class ConfigStore {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import Store from 'electron-store';
 import { PtyManager } from './pty-manager';
 import { ConfigStore } from './config-store';
+import type { BackgroundMaterial } from './config-store';
 import { IPC } from '../shared/ipc-channels';
 import { CopilotSessionMonitor } from './copilot-session-monitor';
 import { CopilotSessionWatcher } from './copilot-session-watcher';
@@ -47,6 +48,59 @@ if (process.platform === 'win32') {
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
 
+/**
+ * Returns true if the current platform supports window background materials
+ * (Windows 11 22H2+ = build 22621+).
+ */
+function platformSupportsMaterial(): boolean {
+  if (process.platform !== 'win32') return false;
+  const release = os.release(); // e.g. "10.0.22621"
+  const parts = release.split('.');
+  const build = parseInt(parts[2], 10);
+  return !isNaN(build) && build >= 22621;
+}
+
+/**
+ * Converts a hex color + opacity (0-1) into an 8-digit hex string (#RRGGBBAA)
+ * that Electron accepts for backgroundColor.
+ */
+function hexWithAlpha(hex: string, opacity: number): string {
+  const clean = hex.replace('#', '');
+  // Normalize 3-char to 6-char, strip existing alpha
+  const normalized = clean.length === 3
+    ? clean.split('').map(c => c + c).join('')
+    : clean.substring(0, 6);
+
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    const alpha = Math.round(Math.max(0, Math.min(1, opacity)) * 255)
+      .toString(16).padStart(2, '0');
+    return `#1e1e2e${alpha}`;
+  }
+
+  const alpha = Math.round(Math.max(0, Math.min(1, opacity)) * 255)
+    .toString(16)
+    .padStart(2, '0');
+  return `#${normalized}${alpha}`;
+}
+
+/**
+ * Returns the effective background material and background color for a window,
+ * based on the current config.
+ */
+function getWindowMaterialOpts(): { backgroundMaterial?: BackgroundMaterial; backgroundColor: string } {
+  const material = (configStore?.get('backgroundMaterial') as BackgroundMaterial) || 'none';
+  const opacity = configStore?.get('backgroundOpacity') as number ?? 0.8;
+  const themeBg = configStore?.get('theme')?.background || '#1e1e2e';
+
+  if (material !== 'none' && platformSupportsMaterial()) {
+    return {
+      backgroundMaterial: material,
+      backgroundColor: hexWithAlpha(themeBg, opacity),
+    };
+  }
+  return { backgroundColor: themeBg };
+}
+
 let mainWindow: BrowserWindow | null = null;
 let ptyManager: PtyManager | null = null;
 let configStore: ConfigStore | null = null;
@@ -68,6 +122,8 @@ function broadcastPtyEvent(channel: string, id: string, ...args: unknown[]) {
 }
 
 function createWindow(): void {
+  const materialOpts = getWindowMaterialOpts();
+
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -77,6 +133,7 @@ function createWindow(): void {
     title: 'tmax',
     icon: path.join(__dirname, '../../assets/icon.png'),
     autoHideMenuBar: true,
+    ...materialOpts,
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
@@ -241,6 +298,24 @@ function registerIpcHandlers(): void {
     IPC.CONFIG_SET,
     (_event, key: string, value: unknown) => {
       configStore!.set(key as keyof ReturnType<ConfigStore['getAll']>, value as never);
+
+      // Dynamically apply background material changes
+      if (key === 'backgroundMaterial' || key === 'backgroundOpacity' || key === 'theme') {
+        const material = (configStore!.get('backgroundMaterial') || 'none') as BackgroundMaterial;
+        const opacity = configStore!.get('backgroundOpacity') as number ?? 0.8;
+        const themeBg = configStore!.get('theme')?.background || '#1e1e2e';
+        const allWindows = [mainWindow, ...detachedWindows.values()];
+        for (const win of allWindows) {
+          if (win && !win.isDestroyed() && platformSupportsMaterial()) {
+            (win as any).setBackgroundMaterial(material);
+            if (material !== 'none') {
+              win.setBackgroundColor(hexWithAlpha(themeBg, opacity));
+            } else {
+              win.setBackgroundColor(themeBg);
+            }
+          }
+        }
+      }
     }
   );
 
@@ -270,11 +345,13 @@ function registerIpcHandlers(): void {
       }
     }
 
+    const detachedMaterialOpts = getWindowMaterialOpts();
     const detachedWin = new BrowserWindow({
       width: 800,
       height: 600,
       title: 'tmax - Terminal',
       autoHideMenuBar: true,
+      ...detachedMaterialOpts,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
@@ -402,6 +479,45 @@ function registerIpcHandlers(): void {
 
   ipcMain.on(IPC.VERSION_RESTART_AND_UPDATE, () => {
     versionChecker?.restartAndUpdate();
+  });
+
+  // ── Transparency IPC handlers ──────────────────────────────────────
+  ipcMain.handle(IPC.SET_BACKGROUND_MATERIAL, (_event, material: string) => {
+    if (!platformSupportsMaterial()) return;
+    const valid: BackgroundMaterial[] = ['none', 'auto', 'mica', 'acrylic', 'tabbed'];
+    if (!valid.includes(material as BackgroundMaterial)) return;
+    const mat = material as BackgroundMaterial;
+
+    // Persist to config
+    configStore!.set('backgroundMaterial', mat);
+
+    const opacity = configStore?.get('backgroundOpacity') as number ?? 0.8;
+    const themeBg = configStore?.get('theme')?.background || '#1e1e2e';
+
+    // Apply to main window
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      (mainWindow as any).setBackgroundMaterial(mat);
+      if (mat !== 'none') {
+        mainWindow.setBackgroundColor(hexWithAlpha(themeBg, opacity));
+      } else {
+        mainWindow.setBackgroundColor(themeBg);
+      }
+    }
+    // Apply to all detached windows
+    for (const [, win] of detachedWindows) {
+      if (!win.isDestroyed()) {
+        (win as any).setBackgroundMaterial(mat);
+        if (mat !== 'none') {
+          win.setBackgroundColor(hexWithAlpha(themeBg, opacity));
+        } else {
+          win.setBackgroundColor(themeBg);
+        }
+      }
+    }
+  });
+
+  ipcMain.handle(IPC.GET_PLATFORM_SUPPORTS_MATERIAL, () => {
+    return platformSupportsMaterial();
   });
 
   ipcMain.handle(IPC.CLIPBOARD_SAVE_IMAGE, (_event, base64Png: string) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -40,6 +40,9 @@ export interface TerminalAPI {
   getPtyDiag(id: string): Promise<PtyDiag | null>;
   diagLog(event: string, data?: Record<string, unknown>): void;
   getDiagLogPath(): Promise<string>;
+  // ── Transparency ──────────────────────────────────────────────────
+  setBackgroundMaterial(material: string): Promise<void>;
+  getPlatformSupportsMaterial(): Promise<boolean>;
   // ── Diff editor ──────────────────────────────────────────────────
   diffResolveGitRoot(cwd: string): Promise<string>;
   diffGetDiff(cwd: string, mode: DiffMode): Promise<DiffResult>;
@@ -294,6 +297,15 @@ const terminalAPI: TerminalAPI = {
     return () => {
       ipcRenderer.removeListener(IPC.VERSION_UPDATE_STATUS, listener);
     };
+  },
+
+  // ── Transparency ────────────────────────────────────────────────
+  setBackgroundMaterial(material: string) {
+    return ipcRenderer.invoke(IPC.SET_BACKGROUND_MATERIAL, material);
+  },
+
+  getPlatformSupportsMaterial(): Promise<boolean> {
+    return ipcRenderer.invoke(IPC.GET_PLATFORM_SUPPORTS_MATERIAL);
   },
 
   // ── Diff editor ──────────────────────────────────────────────────

--- a/src/renderer/DetachedApp.tsx
+++ b/src/renderer/DetachedApp.tsx
@@ -4,6 +4,12 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 
+function hexToTerminalRgba(hex: string, alpha: number): string {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!m) return hex;
+  return `rgba(${parseInt(m[1], 16)}, ${parseInt(m[2], 16)}, ${parseInt(m[3], 16)}, ${alpha})`;
+}
+
 interface DetachedAppProps {
   terminalId: string;
 }
@@ -21,16 +27,21 @@ const DetachedApp: React.FC<DetachedAppProps> = ({ terminalId }) => {
       const themeConfig = config?.theme as Record<string, string> | undefined;
       const termConfig = config?.terminal as Record<string, unknown> | undefined;
 
+      const materialActive = (config as any)?.backgroundMaterial && (config as any).backgroundMaterial !== 'none';
+      const bgOpacity = materialActive ? ((config as any)?.backgroundOpacity ?? 0.8) : 1;
+      const rawBg = themeConfig?.background ?? '#1e1e2e';
+      const bgColor = bgOpacity < 1 ? hexToTerminalRgba(rawBg, bgOpacity) : rawBg;
+
       const term = new Terminal({
         theme: themeConfig
           ? {
-              background: themeConfig.background,
+              background: bgColor,
               foreground: themeConfig.foreground,
               cursor: themeConfig.cursor,
               selectionBackground: themeConfig.selectionBackground,
             }
           : {
-              background: '#1e1e2e',
+              background: bgColor,
               foreground: '#cdd6f4',
               cursor: '#f5e0dc',
               selectionBackground: '#585b70',
@@ -42,6 +53,7 @@ const DetachedApp: React.FC<DetachedAppProps> = ({ terminalId }) => {
         scrollback: (termConfig?.scrollback as number) ?? 5000,
         cursorStyle: (termConfig?.cursorStyle as 'block') ?? 'block',
         cursorBlink: (termConfig?.cursorBlink as boolean) ?? true,
+        allowTransparency: bgOpacity < 1,
         allowProposedApi: true,
       });
 

--- a/src/renderer/components/FloatingRenameInput.tsx
+++ b/src/renderer/components/FloatingRenameInput.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const FloatingRenameInput: React.FC = () => {
+  return null;
+};
+
+export default FloatingRenameInput;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useTerminalStore } from '../state/terminal-store';
 
-type Tab = 'terminal' | 'keybindings' | 'shells' | 'theme';
+type Tab = 'terminal' | 'keybindings' | 'shells' | 'theme' | 'appearance';
 
 const Settings: React.FC = () => {
   const show = useTerminalStore((s) => s.showSettings);
@@ -33,7 +33,7 @@ const Settings: React.FC = () => {
           <button className="shortcuts-close" onClick={close}>&#10005;</button>
         </div>
         <div className="settings-tabs">
-          {(['terminal', 'keybindings', 'shells', 'theme'] as Tab[]).map((t) => (
+          {(['terminal', 'keybindings', 'shells', 'theme', 'appearance'] as Tab[]).map((t) => (
             <button key={t} className={`settings-tab${tab === t ? ' active' : ''}`} onClick={() => setTab(t)}>
               {t.charAt(0).toUpperCase() + t.slice(1)}
             </button>
@@ -44,6 +44,7 @@ const Settings: React.FC = () => {
           {tab === 'keybindings' && <KeybindingsSettings />}
           {tab === 'shells' && <ShellsSettings />}
           {tab === 'theme' && <ThemeSettings />}
+          {tab === 'appearance' && <AppearanceSettings />}
         </div>
       </div>
     </div>
@@ -373,6 +374,77 @@ const ThemeSettings: React.FC = () => {
           </div>
         ))}
       </div>
+    </div>
+  );
+};
+
+// ── Appearance Settings ───────────────────────────────────────────
+
+const MATERIAL_OPTIONS: { value: string; label: string; description: string }[] = [
+  { value: 'none', label: 'None', description: 'Opaque background (default)' },
+  { value: 'mica', label: 'Mica', description: 'Subtle desktop-tinted material' },
+  { value: 'acrylic', label: 'Acrylic', description: 'Frosted glass blur effect' },
+  { value: 'tabbed', label: 'Tabbed', description: 'Tabbed title bar style' },
+  { value: 'auto', label: 'Auto', description: 'System decides the material' },
+];
+
+const AppearanceSettings: React.FC = () => {
+  const config = useTerminalStore((s) => s.config)!;
+  const update = useTerminalStore((s) => s.updateConfig);
+  const [platformSupported, setPlatformSupported] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    window.terminalAPI.getPlatformSupportsMaterial().then(setPlatformSupported);
+  }, []);
+
+  const currentMaterial = (config as any).backgroundMaterial || 'none';
+  const currentOpacity = (config as any).backgroundOpacity ?? 0.8;
+
+  if (platformSupported === false) {
+    return (
+      <div className="settings-section">
+        <div className="settings-hint" style={{ padding: '16px 0' }}>
+          Window transparency effects (Mica, Acrylic) require Windows 11 version 22H2 or later.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-section">
+      <div className="settings-hint">
+        Background material effects are a Windows 11 feature. They apply a system-drawn translucent material behind the window.
+      </div>
+      <SettingRow label="Background Material" description="Window backdrop material type">
+        <select
+          className="settings-input"
+          value={currentMaterial}
+          onChange={(e) => update({ backgroundMaterial: e.target.value } as any)}
+        >
+          {MATERIAL_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label} — {opt.description}
+            </option>
+          ))}
+        </select>
+      </SettingRow>
+      {currentMaterial !== 'none' && (
+        <SettingRow label="Background Opacity" description={`UI chrome opacity: ${Math.round(currentOpacity * 100)}%`}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', width: '100%' }}>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              value={Math.round(currentOpacity * 100)}
+              onChange={(e) => update({ backgroundOpacity: parseInt(e.target.value) / 100 } as any)}
+              style={{ flex: 1 }}
+            />
+            <span style={{ minWidth: 40, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+              {Math.round(currentOpacity * 100)}%
+            </span>
+          </div>
+        </SettingRow>
+      )}
     </div>
   );
 };

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -5,7 +5,14 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { SearchAddon } from '@xterm/addon-search';
 import { useTerminalStore } from '../state/terminal-store';
 import { registerTerminal, unregisterTerminal } from '../terminal-registry';
+import type { AppConfig } from '../state/types';
 import '@xterm/xterm/css/xterm.css';
+
+function hexToTerminalRgba(hex: string, alpha: number): string {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!m) return hex;
+  return `rgba(${parseInt(m[1], 16)}, ${parseInt(m[2], 16)}, ${parseInt(m[3], 16)}, ${alpha})`;
+}
 
 function ago(ts: number): string {
   if (!ts) return 'never';
@@ -125,7 +132,11 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
     const themeConfig = config?.theme;
     const termConfig = config?.terminal;
 
-    const bgColor = themeConfig?.background ?? '#1e1e2e';
+    const rawBg = themeConfig?.background ?? '#1e1e2e';
+    const materialActive = (config as AppConfig)?.backgroundMaterial && (config as AppConfig).backgroundMaterial !== 'none';
+    const bgOpacity = materialActive ? ((config as AppConfig)?.backgroundOpacity ?? 0.8) : 1;
+    // Convert hex to rgba for terminal background when transparency is active
+    const bgColor = bgOpacity < 1 ? hexToTerminalRgba(rawBg, bgOpacity) : rawBg;
     const term = new Terminal({
       theme: themeConfig
         ? {
@@ -145,6 +156,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
       scrollback: termConfig?.scrollback ?? 5000,
       cursorStyle: termConfig?.cursorStyle ?? 'block',
       cursorBlink: termConfig?.cursorBlink ?? true,
+      allowTransparency: bgOpacity < 1,
       allowProposedApi: true,
     });
 

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -51,18 +51,36 @@ function adjustBrightness(hex: string, amount: number): string {
   return `#${[clamp(rgb.r + amount), clamp(rgb.g + amount), clamp(rgb.b + amount)].map(c => c.toString(16).padStart(2, '0')).join('')}`;
 }
 
-export function applyThemeToChromeVars(theme: Record<string, string>): void {
+function hexToRgba(hex: string, alpha: number): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+}
+
+export function applyThemeToChromeVars(theme: Record<string, string>, transparencyOpacity?: number): void {
   const bg = theme.background || '#1e1e2e';
   const fg = theme.foreground || '#cdd6f4';
   const isLight = luminance(bg) > 0.5;
   const step = isLight ? -15 : 15;
+  const useTransparency = transparencyOpacity !== undefined && transparencyOpacity < 1;
 
   const root = document.documentElement;
-  root.style.setProperty('--bg-primary', bg);
-  root.style.setProperty('--bg-secondary', adjustBrightness(bg, step));
+
+  if (useTransparency) {
+    root.style.setProperty('--bg-primary', hexToRgba(bg, transparencyOpacity));
+    root.style.setProperty('--bg-secondary', hexToRgba(adjustBrightness(bg, step), transparencyOpacity));
+    root.style.setProperty('--tab-bg', hexToRgba(adjustBrightness(bg, step), transparencyOpacity));
+    root.style.setProperty('--tab-active', hexToRgba(adjustBrightness(bg, step * 2), transparencyOpacity));
+    root.classList.add('transparency-active');
+  } else {
+    root.style.setProperty('--bg-primary', bg);
+    root.style.setProperty('--bg-secondary', adjustBrightness(bg, step));
+    root.style.setProperty('--tab-bg', adjustBrightness(bg, step));
+    root.style.setProperty('--tab-active', adjustBrightness(bg, step * 2));
+    root.classList.remove('transparency-active');
+  }
+
   root.style.setProperty('--border-color', adjustBrightness(bg, step * 2));
-  root.style.setProperty('--tab-bg', adjustBrightness(bg, step));
-  root.style.setProperty('--tab-active', adjustBrightness(bg, step * 2));
   root.style.setProperty('--text-primary', fg);
   root.style.setProperty('--text-secondary', adjustBrightness(fg, isLight ? 60 : -60));
   root.style.setProperty('--focus-border', theme.blue || '#89b4fa');
@@ -488,7 +506,9 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
 
   loadConfig: async () => {
     const config = (await window.terminalAPI.getConfig()) as unknown as AppConfig;
-    if (config?.theme) applyThemeToChromeVars(config.theme);
+    const materialActive = config?.backgroundMaterial && config.backgroundMaterial !== 'none';
+    const opacity = materialActive ? (config?.backgroundOpacity ?? 0.8) : undefined;
+    if (config?.theme) applyThemeToChromeVars(config.theme, opacity);
     const updates: Record<string, unknown> = { config };
     if (config?.tabBarPosition) updates.tabBarPosition = config.tabBarPosition;
     if (typeof (config as any)?.hideTabTitles === 'boolean') updates.hideTabTitles = (config as any).hideTabTitles;
@@ -1200,7 +1220,11 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     for (const [key, value] of Object.entries(update)) {
       await window.terminalAPI.setConfig(key, value);
     }
-    if (update.theme) applyThemeToChromeVars(newConfig.theme);
+    if (update.theme || update.backgroundMaterial !== undefined || update.backgroundOpacity !== undefined) {
+      const materialActive = newConfig.backgroundMaterial && newConfig.backgroundMaterial !== 'none';
+      const opacity = materialActive ? (newConfig.backgroundOpacity ?? 0.8) : undefined;
+      applyThemeToChromeVars(newConfig.theme, opacity);
+    }
     const extra: Record<string, unknown> = { config: newConfig };
     // Sync store fontSize with config when terminal font size changes
     if (update.terminal?.fontSize) {

--- a/src/renderer/state/types.ts
+++ b/src/renderer/state/types.ts
@@ -91,6 +91,8 @@ export interface TerminalConfig {
   cursorBlink?: boolean;
 }
 
+export type BackgroundMaterial = 'none' | 'auto' | 'mica' | 'acrylic' | 'tabbed';
+
 export interface AppConfig {
   shells: ShellProfile[];
   defaultShellId: string;
@@ -100,6 +102,8 @@ export interface AppConfig {
   copilotCommand?: string;
   claudeCodeCommand?: string;
   tabBarPosition?: 'top' | 'bottom' | 'left' | 'right';
+  backgroundMaterial?: BackgroundMaterial;
+  backgroundOpacity?: number; // 0.0–1.0, default 0.8
 }
 
 // ── Drag & drop ──────────────────────────────────────────────────────

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -31,6 +31,47 @@ body,
   color: var(--text-primary);
 }
 
+/* When mica/acrylic material is active, make root backgrounds transparent
+   so the system-drawn material shows through */
+html.transparency-active,
+html.transparency-active body,
+html.transparency-active #root {
+  background: transparent;
+}
+
+/* Make all chrome layers translucent so the material shows through terminals */
+html.transparency-active .app-shell {
+  background: transparent;
+}
+
+html.transparency-active .tab-bar {
+  background: var(--bg-secondary);
+}
+
+html.transparency-active .tab {
+  background: var(--tab-bg);
+}
+
+html.transparency-active .tab.active {
+  background: var(--bg-primary);
+}
+
+html.transparency-active .status-bar {
+  background: var(--bg-secondary);
+}
+
+html.transparency-active .terminal-panel {
+  background: transparent;
+}
+
+html.transparency-active .split-resizer {
+  background: transparent;
+}
+
+html.transparency-active .xterm-viewport {
+  background: transparent !important;
+}
+
 
 /* ===== App Shell ===== */
 .app-shell {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -42,6 +42,9 @@ export const IPC = {
   PTY_GET_DIAG: 'pty:getDiag',
   DIAG_LOG: 'diag:log',
   DIAG_GET_LOG_PATH: 'diag:getLogPath',
+  // ── Transparency ────────────────────────────────────────────────────
+  SET_BACKGROUND_MATERIAL: 'transparency:setMaterial',
+  GET_PLATFORM_SUPPORTS_MATERIAL: 'transparency:platformSupports',
   // ── Diff editor ────────────────────────────────────────────────────
   DIFF_RESOLVE_GIT_ROOT: 'diff:resolveGitRoot',
   DIFF_GET_CODE_CHANGES: 'diff:getCodeChanges',


### PR DESCRIPTION
## Summary

Adds configurable Windows 11 Mica and Acrylic background material effects to tmax using Electron 30's built-in \ackgroundMaterial\ API. No third-party native modules required.

## Features

- **New Appearance tab** in Settings with material picker (None / Mica / Acrylic / Tabbed / Auto) and opacity slider (0–100%)
- **Live preview** — changes apply immediately without restart
- **Applies to all windows** — main window and detached terminal windows
- **Graceful degradation** — UI hidden on platforms older than Windows 11 22H2+
- **Full-depth transparency** — all CSS layers (app shell, tabs, status bar, terminal panels, xterm canvas) become translucent when a material is active
- xterm \llowTransparency\ enabled for proper canvas alpha rendering

## Config Keys

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| \ackgroundMaterial\ | \'none' \| 'mica' \| 'acrylic' \| 'tabbed' \| 'auto'\ | \'none'\ | Window backdrop material |
| \ackgroundOpacity\ | \
umber\ (0.0–1.0) | \