### PR TITLE
feat: add WSL integration for AI sessions

### DIFF
--- a/src/main/claude-code-session-monitor.ts
+++ b/src/main/claude-code-session-monitor.ts
@@ -24,9 +24,11 @@ export class ClaudeCodeSessionMonitor {
   private filePaths = new Map<string, string>();
   private callbacks: ClaudeCodeMonitorCallbacks = {};
   private readonly basePath: string;
+  private readonly wslDistro?: string;
 
-  constructor() {
-    this.basePath = path.join(os.homedir(), '.claude', 'projects');
+  constructor(options?: { basePath?: string; wslDistro?: string }) {
+    this.basePath = options?.basePath ?? path.join(os.homedir(), '.claude', 'projects');
+    this.wslDistro = options?.wslDistro;
   }
 
   setCallbacks(callbacks: ClaudeCodeMonitorCallbacks): void {
@@ -227,7 +229,7 @@ export class ClaudeCodeSessionMonitor {
       cwdFolder = parts[parts.length - 1] || parsed.cwd;
     }
 
-    return {
+    const summary: CopilotSessionSummary = {
       id: parsed.sessionId,
       provider: 'claude-code',
       status: parsed.status,
@@ -240,5 +242,12 @@ export class ClaudeCodeSessionMonitor {
       lastActivityTime: parsed.lastActivityTime,
       model: parsed.model || undefined,
     };
+
+    if (this.wslDistro) {
+      summary.wsl = true;
+      summary.wslDistro = this.wslDistro;
+    }
+
+    return summary;
   }
 }

--- a/src/main/copilot-session-monitor.ts
+++ b/src/main/copilot-session-monitor.ts
@@ -18,9 +18,11 @@ export class CopilotSessionMonitor {
   private sessions = new Map<string, CopilotSession>();
   private callbacks: CopilotMonitorCallbacks = {};
   private readonly basePath: string;
+  private readonly wslDistro?: string;
 
-  constructor() {
-    this.basePath = path.join(os.homedir(), '.copilot', 'session-state');
+  constructor(options?: { basePath?: string; wslDistro?: string }) {
+    this.basePath = options?.basePath ?? path.join(os.homedir(), '.copilot', 'session-state');
+    this.wslDistro = options?.wslDistro;
   }
 
   setCallbacks(callbacks: CopilotMonitorCallbacks): void {
@@ -262,7 +264,7 @@ export class CopilotSessionMonitor {
   }
 
   private toSummary(session: CopilotSession): CopilotSessionSummary {
-    return {
+    const summary: CopilotSessionSummary = {
       id: session.id,
       provider: 'copilot',
       status: session.status,
@@ -274,5 +276,12 @@ export class CopilotSessionMonitor {
       toolCallCount: session.toolCallCount,
       lastActivityTime: session.lastActivityTime,
     };
+
+    if (this.wslDistro) {
+      summary.wsl = true;
+      summary.wslDistro = this.wslDistro;
+    }
+
+    return summary;
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,6 +12,7 @@ import { CopilotSessionWatcher } from './copilot-session-watcher';
 import { notifyCopilotSession, clearNotificationCooldowns } from './copilot-notification';
 import { ClaudeCodeSessionMonitor } from './claude-code-session-monitor';
 import { ClaudeCodeSessionWatcher } from './claude-code-session-watcher';
+import { WslSessionManager } from './wsl-session-manager';
 import { VersionChecker } from './version-checker';
 import { initDiagLogger, getDiagLogPath, diagLog } from './diag-logger';
 import { GitDiffService, resolveGitRoot } from './git-diff-service';
@@ -128,6 +129,7 @@ let copilotMonitor: CopilotSessionMonitor | null = null;
 let copilotWatcher: CopilotSessionWatcher | null = null;
 let claudeCodeMonitor: ClaudeCodeSessionMonitor | null = null;
 let claudeCodeWatcher: ClaudeCodeSessionWatcher | null = null;
+let wslSessionManager: WslSessionManager | null = null;
 let versionChecker: VersionChecker | null = null;
 let clipboardTempDir: string | null = null;
 const sessionStore = new Store({ name: 'tmax-session' });
@@ -281,7 +283,7 @@ function setupConfigStore(): void {
 function registerIpcHandlers(): void {
   ipcMain.handle(
     IPC.PTY_CREATE,
-    (_event, opts: { id: string; shellPath: string; args: string[]; cwd: string; env?: Record<string, string>; cols: number; rows: number }) => {
+    (_event, opts: { id: string; shellPath: string; args: string[]; cwd: string; env?: Record<string, string>; cols: number; rows: number; wslDistro?: string }) => {
       // Validate shell path against configured profiles to prevent arbitrary exec
       const shells = configStore!.get('shells');
       const profile = shells.find((s: { path: string }) => s.path === opts.shellPath);
@@ -291,7 +293,25 @@ function registerIpcHandlers(): void {
       // Clamp cols/rows to reasonable bounds
       const cols = Math.max(1, Math.min(500, opts.cols || 80));
       const rows = Math.max(1, Math.min(200, opts.rows || 24));
-      return ptyManager!.create({ ...opts, args: profile.args, cols, rows });
+      // For WSL sessions targeting a specific distro, use -d <distro> and --cd <cwd>
+      let args: string[];
+      if (opts.wslDistro) {
+        // Validate distro name: must be alphanumeric/dash/dot only (no shell metacharacters)
+        if (!/^[\w][\w.\-]*$/.test(opts.wslDistro)) {
+          throw new Error(`Invalid WSL distro name: ${opts.wslDistro}`);
+        }
+        args = ['-d', opts.wslDistro];
+        // If the renderer passed a Linux CWD (starts with /), use --cd to set it
+        if (opts.cwd && opts.cwd.startsWith('/')) {
+          args.push('--cd', opts.cwd);
+        }
+      } else {
+        args = profile.args;
+      }
+      const { wslDistro: _wsl, ...ptyOpts } = opts;
+      // For WSL with --cd, node-pty still needs a valid Windows cwd
+      const cwd = opts.wslDistro ? (os.homedir()) : ptyOpts.cwd;
+      return ptyManager!.create({ ...ptyOpts, args, cols, rows, cwd });
     }
   );
 
@@ -454,15 +474,19 @@ function registerIpcHandlers(): void {
 
   // ── Copilot IPC handlers ────────────────────────────────────────────
   ipcMain.handle(IPC.COPILOT_LIST_SESSIONS, () => {
-    return copilotMonitor?.scanSessions() ?? [];
+    const native = copilotMonitor?.scanSessions() ?? [];
+    const wsl = wslSessionManager?.scanCopilotSessions() ?? [];
+    return [...native, ...wsl];
   });
 
   ipcMain.handle(IPC.COPILOT_GET_SESSION, (_event, id: string) => {
-    return copilotMonitor?.getSession(id) ?? null;
+    return copilotMonitor?.getSession(id) ?? wslSessionManager?.getCopilotSession(id) ?? null;
   });
 
   ipcMain.handle(IPC.COPILOT_SEARCH_SESSIONS, (_event, query: string) => {
-    return copilotMonitor?.searchSessions(query) ?? [];
+    const native = copilotMonitor?.searchSessions(query) ?? [];
+    const wsl = wslSessionManager?.searchCopilotSessions(query) ?? [];
+    return [...native, ...wsl];
   });
 
   ipcMain.handle(IPC.COPILOT_START_WATCHING, async () => {
@@ -478,20 +502,26 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(IPC.COPILOT_GET_PROMPTS, (_event, id: string) => {
-    return copilotMonitor?.getPrompts(id) ?? [];
+    const native = copilotMonitor?.getPrompts(id) ?? [];
+    if (native.length > 0) return native;
+    return wslSessionManager?.getCopilotPrompts(id) ?? [];
   });
 
   // ── Claude Code IPC handlers ──────────────────────────────────────────
   ipcMain.handle(IPC.CLAUDE_CODE_LIST_SESSIONS, () => {
-    return claudeCodeMonitor?.scanSessions() ?? [];
+    const native = claudeCodeMonitor?.scanSessions() ?? [];
+    const wsl = wslSessionManager?.scanClaudeCodeSessions() ?? [];
+    return [...native, ...wsl];
   });
 
   ipcMain.handle(IPC.CLAUDE_CODE_GET_SESSION, (_event, id: string) => {
-    return claudeCodeMonitor?.getSession(id) ?? null;
+    return claudeCodeMonitor?.getSession(id) ?? wslSessionManager?.getClaudeCodeSession(id) ?? null;
   });
 
   ipcMain.handle(IPC.CLAUDE_CODE_SEARCH_SESSIONS, (_event, query: string) => {
-    return claudeCodeMonitor?.searchSessions(query) ?? [];
+    const native = claudeCodeMonitor?.searchSessions(query) ?? [];
+    const wsl = wslSessionManager?.searchClaudeCodeSessions(query) ?? [];
+    return [...native, ...wsl];
   });
 
   ipcMain.handle(IPC.CLAUDE_CODE_START_WATCHING, async () => {
@@ -507,7 +537,9 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(IPC.CLAUDE_CODE_GET_PROMPTS, (_event, id: string) => {
-    return claudeCodeMonitor?.getPrompts(id) ?? [];
+    const native = claudeCodeMonitor?.getPrompts(id) ?? [];
+    if (native.length > 0) return native;
+    return wslSessionManager?.getClaudeCodePrompts(id) ?? [];
   });
 
   // ── Version check IPC handlers ──────────────────────────────────────
@@ -580,16 +612,21 @@ function registerIpcHandlers(): void {
   });
 
   // ── File explorer IPC ──────────────────────────────────────────────
-  ipcMain.handle(IPC.FILE_LIST, async (_event, dirPath: string) => {
-    const fs = require('fs');
-    const pathMod = require('path');
+  ipcMain.handle(IPC.FILE_LIST, async (_event, dirPath: string, wslDistro?: string) => {
     try {
-      const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+      // For WSL terminals, translate Linux paths to UNC paths for fs access
+      let fsPath = dirPath;
+      if (wslDistro && dirPath.startsWith('/')) {
+        if (!/^[\w][\w.\-]*$/.test(wslDistro)) return [];
+        fsPath = `\\\\wsl.localhost\\${wslDistro}${dirPath.replace(/\//g, '\\')}`;
+      }
+      const entries = fs.readdirSync(fsPath, { withFileTypes: true });
       return entries
         .map((e: any) => ({
           name: e.name,
           isDirectory: e.isDirectory(),
-          path: pathMod.join(dirPath, e.name),
+          // Return Linux-style paths for WSL so the explorer stays consistent
+          path: wslDistro ? dirPath.replace(/\/$/, '') + '/' + e.name : path.join(dirPath, e.name),
         }))
         .sort((a: any, b: any) => {
           // Directories first, then alphabetical
@@ -668,6 +705,36 @@ function setupClaudeCodeMonitor(): void {
   });
 }
 
+async function setupWslSessionManager(): Promise<void> {
+  if (process.platform !== 'win32') return;
+
+  wslSessionManager = new WslSessionManager();
+
+  wslSessionManager.setCallbacks({
+    onCopilotSessionUpdated(session) {
+      mainWindow?.webContents.send(IPC.COPILOT_SESSION_UPDATED, session);
+      notifyCopilotSession(session);
+    },
+    onCopilotSessionAdded(session) {
+      mainWindow?.webContents.send(IPC.COPILOT_SESSION_ADDED, session);
+    },
+    onCopilotSessionRemoved(sessionId) {
+      mainWindow?.webContents.send(IPC.COPILOT_SESSION_REMOVED, sessionId);
+    },
+    onClaudeCodeSessionUpdated(session) {
+      mainWindow?.webContents.send(IPC.CLAUDE_CODE_SESSION_UPDATED, session);
+    },
+    onClaudeCodeSessionAdded(session) {
+      mainWindow?.webContents.send(IPC.CLAUDE_CODE_SESSION_ADDED, session);
+    },
+    onClaudeCodeSessionRemoved(sessionId) {
+      mainWindow?.webContents.send(IPC.CLAUDE_CODE_SESSION_REMOVED, sessionId);
+    },
+  });
+
+  await wslSessionManager.start();
+}
+
 process.on('uncaughtException', (error) => {
   console.error('Uncaught exception in main process:', error);
 });
@@ -722,6 +789,13 @@ app.whenReady().then(() => {
     versionChecker = new VersionChecker(mainWindow!);
     versionChecker.start();
     console.log('Version checker started');
+    // Start WSL discovery after window is visible — WSL distro detection
+    // uses synchronous subprocess calls that can block for several seconds
+    setupWslSessionManager().then(() => {
+      console.log('WSL session manager ready');
+    }).catch((err) => {
+      console.error('WSL session manager failed:', err);
+    });
   } catch (error) {
     console.error('Startup error:', error);
   }
@@ -750,6 +824,7 @@ app.on('window-all-closed', async () => {
   copilotMonitor?.dispose();
   await claudeCodeWatcher?.stop();
   claudeCodeMonitor?.dispose();
+  await wslSessionManager?.stop();
   versionChecker?.stop();
   clearNotificationCooldowns();
   app.quit();

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -138,6 +138,15 @@ export class PtyManager {
       // Send as a single line + Enter, then clear screen to hide the init noise
       setTimeout(() => ptyProcess.write(psSnippet + '\r'), 200);
       setTimeout(() => ptyProcess.write('cls\r'), 400);
+    } else if (shellName.includes('wsl')) {
+      // WSL: shell init (oh-my-zsh, bashrc) takes longer than native shells.
+      // Skip automatic CWD hook injection — it flashes visibly before the shell
+      // is ready. CWD tracking for plain WSL terminals falls back to prompt
+      // regex detection, and AI session terminals don't need it.
+    } else if (shellName.includes('bash') || shellName.includes('zsh')) {
+      // Bash/Zsh: use PROMPT_COMMAND / precmd
+      const bashSnippet = 'PROMPT_COMMAND=\'printf "\\e]7;file:///%s\\a" "$(pwd)"\'' + '\r';
+      setTimeout(() => ptyProcess.write(bashSnippet), 200);
     }
     // CMD: relies on prompt regex fallback (no hook mechanism)
 

--- a/src/main/wsl-session-manager.ts
+++ b/src/main/wsl-session-manager.ts
@@ -1,0 +1,181 @@
+import { ClaudeCodeSessionMonitor } from './claude-code-session-monitor';
+import { ClaudeCodeSessionWatcher } from './claude-code-session-watcher';
+import { CopilotSessionMonitor } from './copilot-session-monitor';
+import { CopilotSessionWatcher } from './copilot-session-watcher';
+import { getWslDistroInfo, isWslAvailable } from './wsl-utils';
+import type { CopilotSessionSummary } from '../shared/copilot-types';
+
+export interface WslSessionCallbacks {
+  onCopilotSessionUpdated?: (session: CopilotSessionSummary) => void;
+  onCopilotSessionAdded?: (session: CopilotSessionSummary) => void;
+  onCopilotSessionRemoved?: (sessionId: string) => void;
+  onClaudeCodeSessionUpdated?: (session: CopilotSessionSummary) => void;
+  onClaudeCodeSessionAdded?: (session: CopilotSessionSummary) => void;
+  onClaudeCodeSessionRemoved?: (sessionId: string) => void;
+}
+
+interface DistroPair {
+  distro: string;
+  copilotMonitor: CopilotSessionMonitor;
+  copilotWatcher: CopilotSessionWatcher;
+  claudeMonitor: ClaudeCodeSessionMonitor;
+  claudeWatcher: ClaudeCodeSessionWatcher;
+}
+
+/**
+ * Manages session monitors/watchers for all detected WSL distros.
+ * Only active on Windows when WSL is available.
+ */
+export class WslSessionManager {
+  private pairs: DistroPair[] = [];
+  private callbacks: WslSessionCallbacks = {};
+
+  setCallbacks(callbacks: WslSessionCallbacks): void {
+    this.callbacks = callbacks;
+  }
+
+  async start(): Promise<void> {
+    if (!isWslAvailable()) return;
+
+    const distros = await getWslDistroInfo();
+
+    for (const distro of distros) {
+      const copilotMonitor = new CopilotSessionMonitor({
+        basePath: distro.copilotBasePath,
+        wslDistro: distro.name,
+      });
+      copilotMonitor.setCallbacks({
+        onSessionUpdated: (s) => this.callbacks.onCopilotSessionUpdated?.(s),
+        onSessionAdded: (s) => this.callbacks.onCopilotSessionAdded?.(s),
+        onSessionRemoved: (id) => this.callbacks.onCopilotSessionRemoved?.(id),
+      });
+
+      const copilotWatcher = new CopilotSessionWatcher(distro.copilotBasePath, {
+        onEventsChanged: (id) => copilotMonitor.handleEventsChanged(id),
+        onNewSession: (id) => copilotMonitor.handleNewSession(id),
+        onSessionRemoved: (id) => copilotMonitor.handleSessionRemoved(id),
+      });
+      copilotWatcher.setStaleCheckCallback(() => copilotMonitor.scanSessions());
+
+      const claudeMonitor = new ClaudeCodeSessionMonitor({
+        basePath: distro.claudeBasePath,
+        wslDistro: distro.name,
+      });
+      claudeMonitor.setCallbacks({
+        onSessionUpdated: (s) => this.callbacks.onClaudeCodeSessionUpdated?.(s),
+        onSessionAdded: (s) => this.callbacks.onClaudeCodeSessionAdded?.(s),
+        onSessionRemoved: (id) => this.callbacks.onClaudeCodeSessionRemoved?.(id),
+      });
+
+      const claudeWatcher = new ClaudeCodeSessionWatcher(distro.claudeBasePath, {
+        onFileChanged: (fp) => claudeMonitor.handleFileChanged(fp),
+        onNewFile: (fp) => claudeMonitor.handleNewFile(fp),
+        onFileRemoved: (fp) => claudeMonitor.handleFileRemoved(fp),
+      });
+      claudeWatcher.setStaleCheckCallback(() => claudeMonitor.scanSessions());
+
+      this.pairs.push({
+        distro: distro.name,
+        copilotMonitor,
+        copilotWatcher,
+        claudeMonitor,
+        claudeWatcher,
+      });
+    }
+
+    // Start all watchers — isolate per-distro so one failure doesn't block others
+    for (const pair of this.pairs) {
+      try {
+        await pair.copilotWatcher.start();
+        await pair.claudeWatcher.start();
+      } catch (err) {
+        console.error(`WSL watcher failed for distro ${pair.distro}:`, err);
+      }
+    }
+
+    // Perform initial scan to discover existing sessions
+    // (watchers use ignoreInitial: true, so won't detect pre-existing files)
+    for (const pair of this.pairs) {
+      try {
+        pair.copilotMonitor.scanSessions();
+        pair.claudeMonitor.scanSessions();
+      } catch (err) {
+        console.error(`WSL scan failed for distro ${pair.distro}:`, err);
+      }
+    }
+  }
+
+  scanCopilotSessions(): CopilotSessionSummary[] {
+    const results: CopilotSessionSummary[] = [];
+    for (const pair of this.pairs) {
+      results.push(...pair.copilotMonitor.scanSessions());
+    }
+    return results;
+  }
+
+  scanClaudeCodeSessions(): CopilotSessionSummary[] {
+    const results: CopilotSessionSummary[] = [];
+    for (const pair of this.pairs) {
+      results.push(...pair.claudeMonitor.scanSessions());
+    }
+    return results;
+  }
+
+  getCopilotSession(id: string): ReturnType<CopilotSessionMonitor['getSession']> {
+    for (const pair of this.pairs) {
+      const session = pair.copilotMonitor.getSession(id);
+      if (session) return session;
+    }
+    return null;
+  }
+
+  getClaudeCodeSession(id: string): CopilotSessionSummary | null {
+    for (const pair of this.pairs) {
+      const session = pair.claudeMonitor.getSession(id);
+      if (session) return session;
+    }
+    return null;
+  }
+
+  searchCopilotSessions(query: string): CopilotSessionSummary[] {
+    const results: CopilotSessionSummary[] = [];
+    for (const pair of this.pairs) {
+      results.push(...pair.copilotMonitor.searchSessions(query));
+    }
+    return results;
+  }
+
+  searchClaudeCodeSessions(query: string): CopilotSessionSummary[] {
+    const results: CopilotSessionSummary[] = [];
+    for (const pair of this.pairs) {
+      results.push(...pair.claudeMonitor.searchSessions(query));
+    }
+    return results;
+  }
+
+  getCopilotPrompts(sessionId: string, limit?: number): string[] {
+    for (const pair of this.pairs) {
+      const session = pair.copilotMonitor.getSession(sessionId);
+      if (session) return pair.copilotMonitor.getPrompts(sessionId, limit);
+    }
+    return [];
+  }
+
+  getClaudeCodePrompts(sessionId: string, limit?: number): string[] {
+    for (const pair of this.pairs) {
+      const session = pair.claudeMonitor.getSession(sessionId);
+      if (session) return pair.claudeMonitor.getPrompts(sessionId, limit);
+    }
+    return [];
+  }
+
+  async stop(): Promise<void> {
+    for (const pair of this.pairs) {
+      await pair.copilotWatcher.stop();
+      await pair.claudeWatcher.stop();
+      pair.copilotMonitor.dispose();
+      pair.claudeMonitor.dispose();
+    }
+    this.pairs = [];
+  }
+}

--- a/src/main/wsl-utils.ts
+++ b/src/main/wsl-utils.ts
@@ -1,0 +1,111 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+
+export interface WslDistroInfo {
+  name: string;
+  home: string;
+  claudeBasePath: string;
+  copilotBasePath: string;
+}
+
+const WSL_LOCALHOST = '\\\\wsl.localhost';
+const WSL_EXE = 'wsl.exe';
+
+let cachedDistros: WslDistroInfo[] | null = null;
+
+export function isWslAvailable(): boolean {
+  if (process.platform !== 'win32') return false;
+  try {
+    const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+    return existsSync(path.join(systemRoot, 'System32', WSL_EXE));
+  } catch {
+    return false;
+  }
+}
+
+function getInstalledDistros(): string[] {
+  try {
+    const raw = execFileSync(WSL_EXE, ['-l', '-q'], {
+      encoding: 'utf16le',
+      timeout: 10_000,
+      windowsHide: true,
+    });
+
+    return raw
+      .replace(/\0/g, '')
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.startsWith('Windows Subsystem'));
+  } catch {
+    return [];
+  }
+}
+
+function getDistroHome(distro: string): string | null {
+  try {
+    const raw = execFileSync(WSL_EXE, ['-d', distro, '-e', '/bin/sh', '-c', 'echo $HOME'], {
+      encoding: 'utf-8',
+      timeout: 10_000,
+      windowsHide: true,
+    });
+
+    const home = raw.replace(/\0/g, '').trim();
+    return home.length > 0 && home.startsWith('/') ? home : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildUncPath(distro: string, linuxPath: string): string {
+  // Convert forward slashes to backslashes for the Windows UNC path portion
+  const winSegment = linuxPath.replace(/\//g, '\\');
+  return `${WSL_LOCALHOST}\\${distro}${winSegment}`;
+}
+
+export async function getWslDistroInfo(): Promise<WslDistroInfo[]> {
+  if (cachedDistros !== null) return cachedDistros;
+
+  if (!isWslAvailable()) {
+    cachedDistros = [];
+    return cachedDistros;
+  }
+
+  const names = getInstalledDistros();
+  const results: WslDistroInfo[] = [];
+
+  for (const name of names) {
+    const home = getDistroHome(name);
+    if (!home) continue;
+
+    results.push({
+      name,
+      home,
+      claudeBasePath: buildUncPath(name, `${home}/.claude/projects`),
+      copilotBasePath: buildUncPath(name, `${home}/.copilot/session-state`),
+    });
+  }
+
+  // Only cache non-empty results — if WSL returned nothing, the service may
+  // not be ready yet, so retry on the next call
+  if (results.length > 0) {
+    cachedDistros = results;
+  }
+  return results;
+}
+
+export function wslUncToLinux(uncPath: string, distro: string): string {
+  const prefix = `${WSL_LOCALHOST}\\${distro}`;
+  if (!uncPath.startsWith(prefix)) {
+    throw new Error(`Path does not start with expected prefix: ${prefix}`);
+  }
+  return uncPath.slice(prefix.length).replace(/\\/g, '/');
+}
+
+export function linuxToWslUnc(linuxPath: string, distro: string): string {
+  return buildUncPath(distro, linuxPath);
+}
+
+export function clearWslCache(): void {
+  cachedDistros = null;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -20,6 +20,7 @@ export interface TerminalAPI {
     env?: Record<string, string>;
     cols: number;
     rows: number;
+    wslDistro?: string;
   }): Promise<{ id: string; pid: number }>;
   writePty(id: string, data: string): void;
   resizePty(id: string, cols: number, rows: number): Promise<void>;
@@ -49,7 +50,7 @@ export interface TerminalAPI {
   diffGetDiff(cwd: string, mode: DiffMode): Promise<DiffResult>;
   diffGetAnnotatedFile(cwd: string, filePath: string, mode: DiffMode): Promise<AnnotatedFile>;
   // ── File explorer ────────────────────────────────────────────────
-  fileList(dirPath: string): Promise<{ name: string; isDirectory: boolean; path: string }[]>;
+  fileList(dirPath: string, wslDistro?: string): Promise<{ name: string; isDirectory: boolean; path: string }[]>;
 }
 
 const terminalAPI: TerminalAPI = {
@@ -329,8 +330,8 @@ const terminalAPI: TerminalAPI = {
   },
 
   // ── File explorer ──────────────────────────────────────────────
-  fileList(dirPath: string) {
-    return ipcRenderer.invoke(IPC.FILE_LIST, dirPath);
+  fileList(dirPath: string, wslDistro?: string) {
+    return ipcRenderer.invoke(IPC.FILE_LIST, dirPath, wslDistro);
   },
 
 };

--- a/src/renderer/components/CopilotPanel.tsx
+++ b/src/renderer/components/CopilotPanel.tsx
@@ -470,6 +470,11 @@ const CopilotPanel: React.FC = () => {
                     </span>
                   )}
                   {isOpen && <span className="ai-open-badge">OPEN</span>}
+                  {session.wsl && (
+                    <span className="ai-wsl-badge" title={session.wslDistro || 'WSL'}>
+                      {session.wslDistro || 'WSL'}
+                    </span>
+                  )}
                   {time && <span className="ai-session-time">{time}</span>}
                 </div>
                 {subtitle && (

--- a/src/renderer/components/FileExplorer.tsx
+++ b/src/renderer/components/FileExplorer.tsx
@@ -17,6 +17,7 @@ const FileExplorer: React.FC = () => {
   const terminals = useTerminalStore((s) => s.terminals);
   const focused = focusedId ? terminals.get(focusedId) : null;
   const terminalCwd = focused?.cwd || '';
+  const wslDistro = focused?.wslDistro;
 
   const [browsePath, setBrowsePath] = useState('');
   const [files, setFiles] = useState<FileEntry[]>([]);
@@ -47,33 +48,39 @@ const FileExplorer: React.FC = () => {
 
   const navigateUp = useCallback(() => {
     if (!currentPath) return;
-    const parent = currentPath.replace(/[/\\][^/\\]+[/\\]?$/, '') || currentPath.slice(0, 3); // e.g. C:\
+    const parent = currentPath.replace(/[/\\][^/\\]+[/\\]?$/, '') || currentPath.slice(0, 3);
     navigateTo(parent);
   }, [currentPath, navigateTo]);
 
   // Load root directory
   useEffect(() => {
     if (!show || !currentPath) return;
-    (window.terminalAPI as any).fileList(currentPath).then((entries: FileEntry[]) => {
+    (window.terminalAPI as any).fileList(currentPath, wslDistro).then((entries: FileEntry[]) => {
       setFiles(showHidden ? entries : entries.filter((e: FileEntry) => !e.name.startsWith('.')));
     });
-  }, [currentPath, show, showHidden]);
+  }, [currentPath, show, showHidden, wslDistro]);
 
   const toggleDir = useCallback((dirPath: string) => {
     setExpanded((prev) => {
       const next = { ...prev, [dirPath]: !prev[dirPath] };
       if (next[dirPath] && !children[dirPath]) {
-        (window.terminalAPI as any).fileList(dirPath).then((entries: FileEntry[]) => {
+        (window.terminalAPI as any).fileList(dirPath, wslDistro).then((entries: FileEntry[]) => {
           setChildren((c) => ({ ...c, [dirPath]: showHidden ? entries : entries.filter((e: FileEntry) => !e.name.startsWith('.')) }));
         });
       }
       return next;
     });
-  }, [children]);
+  }, [children, wslDistro]);
 
   const handleFileClick = useCallback((filePath: string) => {
-    (window.terminalAPI as any).openPath(filePath);
-  }, []);
+    // For WSL files, translate Linux path to UNC for Windows to open
+    if (wslDistro && filePath.startsWith('/')) {
+      const uncPath = `\\\\wsl.localhost\\${wslDistro}${filePath.replace(/\//g, '\\')}`;
+      (window.terminalAPI as any).openPath(uncPath);
+    } else {
+      (window.terminalAPI as any).openPath(filePath);
+    }
+  }, [wslDistro]);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -15,6 +15,58 @@ function hexToTerminalRgba(hex: string, alpha: number): string {
   return `rgba(${parseInt(m[1], 16)}, ${parseInt(m[2], 16)}, ${parseInt(m[3], 16)}, ${alpha})`;
 }
 
+const WSL_PROMPT_DEBOUNCE_MS = 200;
+const WSL_PROMPT_FALLBACK_MS = 5000;
+
+/**
+ * Sends a command to a WSL terminal after detecting the shell prompt.
+ * Uses debounce to avoid firing on MOTD/banner text, with a fallback timeout.
+ * Returns a cleanup function for useEffect teardown.
+ */
+function sendCommandOnWslPrompt(
+  terminalId: string,
+  cmd: string,
+  onSent?: (cmd: string) => void,
+): () => void {
+  let promptSent = false;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const checkPrompt = (id: string, data: string) => {
+    if (id !== terminalId || promptSent) return;
+    const clean = data.replace(/\x1b\[[^m]*m/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+    // $/#/% = sh/bash/zsh; ❯/➜ = Oh-My-Zsh/Starship; > = fish/generic
+    if (/[$#%❯➜>]\s*$/.test(clean)) {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        if (!promptSent) {
+          promptSent = true;
+          promptUnsub();
+          window.terminalAPI.writePty(terminalId, cmd + '\r');
+          onSent?.(cmd);
+        }
+      }, WSL_PROMPT_DEBOUNCE_MS);
+    }
+  };
+
+  const promptUnsub = window.terminalAPI.onPtyData(checkPrompt);
+
+  const fallbackTimer = setTimeout(() => {
+    if (!promptSent) {
+      promptSent = true;
+      promptUnsub();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      window.terminalAPI.writePty(terminalId, cmd + '\r');
+      onSent?.(cmd);
+    }
+  }, WSL_PROMPT_FALLBACK_MS);
+
+  return () => {
+    promptUnsub();
+    clearTimeout(fallbackTimer);
+    if (debounceTimer) clearTimeout(debounceTimer);
+  };
+}
+
 function ago(ts: number): string {
   if (!ts) return 'never';
   const s = (Date.now() - ts) / 1000;
@@ -103,6 +155,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
   );
   const aiResumeCommandRef = useRef<string>('');
   const aiSessionStartedRef = useRef(false);
+  const wslPromptCleanupRef = useRef<(() => void) | null>(null);
   const isFocused = focusedTerminalId === terminalId;
 
   const handleFocus = useCallback(() => {
@@ -304,10 +357,16 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
           // 3. Prompt regex fallback: "PS C:\path>" or "C:\path>"
           let detectedDir: string | null = null;
 
+          // Check if this is a WSL terminal (preserve Linux-style paths)
+          const termInst = useTerminalStore.getState().terminals.get(terminalId);
+          const isWsl = termInst?.wsl === true;
+
           // Try OSC 7 (file URI)
           const osc7Match = data.match(/\x1b\]7;file:\/\/[^/]*\/([^\x07\x1b]+)(?:\x07|\x1b\\)/);
           if (osc7Match) {
-            detectedDir = decodeURIComponent(osc7Match[1]).replace(/\//g, '\\');
+            const decoded = decodeURIComponent(osc7Match[1]);
+            // For WSL terminals, keep Linux-style forward slashes; prefix with / for absolute path
+            detectedDir = isWsl ? '/' + decoded : decoded.replace(/\//g, '\\');
           }
 
           // Try OSC 9;9 (Windows Terminal / ConPTY)
@@ -370,16 +429,24 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
     const termInstance = useTerminalStore.getState().terminals.get(terminalId);
     if (termInstance?.startupCommand && !termInstance.startupCommandSent) {
       const cmd = termInstance.startupCommand;
-      // Save resume command for AI sessions so we can pre-fill it on exit
-      if (termInstance.aiSessionId) {
-        aiResumeCommandRef.current = cmd;
+      if (termInstance.wsl) {
+        // WSL: wait for the shell prompt before sending the command
+        wslPromptCleanupRef.current = sendCommandOnWslPrompt(terminalId, cmd, (sentCmd) => {
+          if (termInstance.aiSessionId) {
+            aiResumeCommandRef.current = sentCmd;
+            aiSessionStartedRef.current = true;
+          }
+        });
+      } else {
+        setTimeout(() => {
+          window.terminalAPI.writePty(terminalId, cmd + '\r');
+          // Arm the re-send mechanism for native AI sessions only.
+          if (termInstance.aiSessionId) {
+            aiResumeCommandRef.current = cmd;
+            aiSessionStartedRef.current = true;
+          }
+        }, 1500);
       }
-      setTimeout(() => {
-        window.terminalAPI.writePty(terminalId, cmd + '\r');
-        if (termInstance.aiSessionId) {
-          aiSessionStartedRef.current = true;
-        }
-      }, 1500);
       // Mark as sent so it doesn't re-run on hot reload, but keep the value for session save
       const store = useTerminalStore.getState();
       const newTerminals = new Map(store.terminals);
@@ -512,6 +579,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
       dataDisposable.dispose();
       unsubscribePtyData();
       unsubscribePtyExit();
+      wslPromptCleanupRef.current?.();
       if (textareaEl) {
         textareaEl.removeEventListener('focus', handleFocus);
         textareaEl.removeEventListener('blur', handleBlur);

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -16,7 +16,149 @@ import type { CopilotSessionSummary } from '../../shared/copilot-types';
 import type { DiffMode } from '../../shared/diff-types';
 import { getAllTerminals } from '../terminal-registry';
 
-// ── Tab color palette ────────────────────────────────────────────────
+// Session IDs must be alphanumeric/dash/dot/underscore only (prevent shell injection)
+const SAFE_SESSION_ID = /^[a-zA-Z0-9._-]+$/;
+
+function validateSessionId(id: string): boolean {
+  return SAFE_SESSION_ID.test(id);
+}
+
+type SessionProvider = 'copilot' | 'claude-code';
+
+function buildResumeCommand(config: AppConfig, provider: SessionProvider, sessionId: string): string {
+  const cmd = provider === 'copilot'
+    ? (config.copilotCommand || 'agency copilot')
+    : (config.claudeCodeCommand || 'claude');
+  return `${cmd} --resume ${sessionId}`;
+}
+
+async function openAiSession(
+  sessionId: string,
+  provider: SessionProvider,
+  get: () => TerminalStore,
+  set: (partial: Partial<TerminalStore> | ((s: TerminalStore) => Partial<TerminalStore>)) => void,
+): Promise<void> {
+  if (!validateSessionId(sessionId)) return;
+
+  // If a terminal with this session is already open, just focus it
+  const { terminals: existingTerminals } = get();
+  for (const [id, inst] of existingTerminals) {
+    if (inst.aiSessionId === sessionId) {
+      set({ focusedTerminalId: id });
+      return;
+    }
+  }
+
+  // Fetch session details via IPC
+  const session = provider === 'copilot'
+    ? await (window.terminalAPI as any).getCopilotSession(sessionId)
+    : await (window.terminalAPI as any).getClaudeCodeSession(sessionId);
+  if (!session) return;
+
+  const store = get();
+  const config = store.config;
+  if (!config) return;
+
+  // Determine WSL status from the session summary list
+  const sessionList = provider === 'copilot' ? store.copilotSessions : store.claudeCodeSessions;
+  const sessionSummary = sessionList.find((s) => s.id === sessionId);
+  const isWsl = sessionSummary?.wsl === true;
+  const wslDistro = sessionSummary?.wslDistro;
+
+  // Extract CWD from the session (different shape per provider)
+  const sessionCwd = provider === 'copilot' ? session.workspace?.cwd : session.cwd;
+
+  const id = uuidv4();
+  let shellProfileId: string;
+  let shellPath: string;
+  let shellArgs: string[];
+  let shellEnv: Record<string, string> | undefined;
+  let termCwd: string;
+
+  if (isWsl && wslDistro) {
+    const wslProfile = config.shells.find((s) => s.id === 'wsl');
+    if (!wslProfile) return;
+    shellProfileId = 'wsl';
+    shellPath = wslProfile.path;
+    shellArgs = wslProfile.args;
+    shellEnv = wslProfile.env;
+    termCwd = sessionCwd || '/';
+  } else {
+    const profileId = config.defaultShellId;
+    const profile = config.shells.find((s) => s.id === profileId);
+    if (!profile) return;
+    shellProfileId = profileId;
+    shellPath = profile.path;
+    shellArgs = profile.args;
+    shellEnv = profile.env;
+    termCwd = sessionCwd || profile.cwd || (navigator.platform.startsWith('Win') ? 'C:\\Users' : '/');
+  }
+
+  const startupCommand = buildResumeCommand(config, provider, sessionId);
+
+  const { pid } = await window.terminalAPI.createPty({
+    id, shellPath, args: shellArgs, cwd: termCwd, env: shellEnv,
+    cols: 80, rows: 24,
+    wslDistro: isWsl ? wslDistro : undefined,
+  });
+
+  // Build display title
+  let displayName: string;
+  if (provider === 'copilot') {
+    displayName = session.workspace?.summary
+      || (session.workspace?.repository ? session.workspace.repository.split('/').pop() : null)
+      || session.workspace?.name
+      || sessionId.slice(0, 8);
+  } else {
+    displayName = session.summary || sessionId.slice(0, 8);
+  }
+
+  const instance: TerminalInstance = {
+    id,
+    title: displayName,
+    shellProfileId,
+    cwd: isWsl ? (sessionCwd || termCwd) : termCwd,
+    customTitle: true,
+    aiAutoTitle: true,
+    mode: 'tiled',
+    pid,
+    lastProcess: '',
+    startupCommand,
+    aiSessionId: sessionId,
+    wsl: isWsl || undefined,
+    wslDistro: wslDistro || undefined,
+  };
+
+  const { terminals, layout } = get();
+  const newTerminals = new Map(terminals);
+  newTerminals.set(id, instance);
+  const newLeaf: LayoutLeafNode = { kind: 'leaf', terminalId: id };
+  let newRoot: LayoutNode;
+  if (layout.tilingRoot === null) {
+    newRoot = newLeaf;
+  } else {
+    const order = getLeafOrder(layout.tilingRoot);
+    newRoot = insertLeaf(layout.tilingRoot, order[order.length - 1], id, 'right');
+  }
+
+  const { viewMode, preGridRoot, gridColumns } = get();
+  let newPreGridRoot = preGridRoot;
+  if (viewMode === 'grid') {
+    if (preGridRoot) {
+      const preOrder = getLeafOrder(preGridRoot);
+      newPreGridRoot = insertLeaf(preGridRoot, preOrder[preOrder.length - 1], id, 'right');
+    }
+    const allIds = getLeafOrder(newRoot);
+    newRoot = buildGridTree(allIds, gridColumns || undefined) || newRoot;
+  }
+
+  set({
+    terminals: newTerminals,
+    layout: { ...layout, tilingRoot: newRoot },
+    focusedTerminalId: id,
+    preGridRoot: newPreGridRoot,
+  });
+}
 
 export const TAB_COLORS = [
   // First 4 = Microsoft logo colors
@@ -1625,10 +1767,10 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   addRecentDir: (dir: string) => {
     // Only add actual directories, not executable paths or garbled terminal output
     if (/\.(exe|cmd|bat|com|ps1|sh|msi|dll)$/i.test(dir)) return;
-    // Reject paths containing ANSI escapes, control chars, or shell operators
-    if (/[\x1b\x00-\x1f]|&&|\|\||[><|'"]/.test(dir)) return;
-    // Must look like a real path (drive letter or unix root)
-    if (!/^[A-Z]:\\/i.test(dir) && !dir.startsWith('/')) return;
+    // Reject paths containing ANSI escapes, control chars, shell operators, or command substitution
+    if (/[\x1b\x00-\x1f`$]|&&|\|\||[><|'"]|\$\(/.test(dir)) return;
+    // Must look like a real path (drive letter, unix root, or WSL UNC path)
+    if (!/^[A-Z]:\\/i.test(dir) && !dir.startsWith('/') && !/^\\\\wsl/i.test(dir)) return;
     const { recentDirs } = get();
     const filtered = recentDirs.filter((d) => d !== dir);
     const updated = [dir, ...filtered].slice(0, 10);
@@ -1643,9 +1785,14 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   },
 
   cdToDir: (dir: string) => {
-    const { focusedTerminalId } = get();
+    const { focusedTerminalId, terminals } = get();
     if (!focusedTerminalId) return;
-    window.terminalAPI.writePty(focusedTerminalId, `cd "${dir}"\r`);
+    // Use single quotes for POSIX shells to prevent command substitution;
+    // double quotes for Windows shells (no $() expansion risk)
+    const terminal = terminals.get(focusedTerminalId);
+    const isWslOrUnix = terminal?.wsl || dir.startsWith('/');
+    const quoted = isWslOrUnix ? `'${dir.replace(/'/g, "'\\''")}'` : `"${dir}"`;
+    window.terminalAPI.writePty(focusedTerminalId, `cd ${quoted}\r`);
     get().addRecentDir(dir);
   },
 
@@ -1686,11 +1833,12 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     // startupCommand (e.g. user opened copilot, exited, then started claude manually).
     function getStartupCommand(t: TerminalInstance | undefined): string {
       if (!t) return '';
-      if (t.aiSessionId) {
+      if (t.aiSessionId && config) {
+        if (!validateSessionId(t.aiSessionId)) return '';
         const isCopilot = copilotSessions.some((s) => s.id === t.aiSessionId);
-        if (isCopilot) return `${config?.copilotCommand || 'agency copilot'} --resume ${t.aiSessionId}`;
+        if (isCopilot) return buildResumeCommand(config, 'copilot', t.aiSessionId);
         const isClaude = claudeCodeSessions.some((s) => s.id === t.aiSessionId);
-        if (isClaude) return `${config?.claudeCodeCommand || 'claude'} --resume ${t.aiSessionId}`;
+        if (isClaude) return buildResumeCommand(config, 'claude-code', t.aiSessionId);
       }
       return t.startupCommand || '';
     }
@@ -1698,7 +1846,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     function serializeNode(node: LayoutNode): unknown {
       if (node.kind === 'leaf') {
         const t = terminals.get(node.terminalId);
-        return { kind: 'leaf', terminal: { title: t?.title ?? 'Terminal', shellProfileId: t?.shellProfileId ?? '', cwd: t?.cwd ?? 'C:\\Users', startupCommand: getStartupCommand(t), aiSessionId: t?.aiSessionId, aiAutoTitle: t?.aiAutoTitle, tabColor: t?.tabColor, customTitle: t?.customTitle } };
+        return { kind: 'leaf', terminal: { title: t?.title ?? 'Terminal', shellProfileId: t?.shellProfileId ?? '', cwd: t?.cwd ?? 'C:\\Users', startupCommand: getStartupCommand(t), aiSessionId: t?.aiSessionId, aiAutoTitle: t?.aiAutoTitle, tabColor: t?.tabColor, customTitle: t?.customTitle, wsl: t?.wsl, wslDistro: t?.wslDistro } };
       }
       return { kind: 'split', direction: node.direction, splitRatio: node.splitRatio, first: serializeNode(node.first), second: serializeNode(node.second) };
     }
@@ -1712,7 +1860,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       tree: layout.tilingRoot ? serializeNode(layout.tilingRoot) : null,
       floating: layout.floatingPanels.map((p) => {
         const t = terminals.get(p.terminalId);
-        return { terminal: { title: t?.title ?? 'Terminal', shellProfileId: t?.shellProfileId ?? '', cwd: t?.cwd ?? 'C:\\Users', startupCommand: getStartupCommand(t), aiSessionId: t?.aiSessionId, aiAutoTitle: t?.aiAutoTitle, tabColor: t?.tabColor, customTitle: t?.customTitle }, x: p.x, y: p.y, width: p.width, height: p.height };
+        return { terminal: { title: t?.title ?? 'Terminal', shellProfileId: t?.shellProfileId ?? '', cwd: t?.cwd ?? 'C:\\Users', startupCommand: getStartupCommand(t), aiSessionId: t?.aiSessionId, aiAutoTitle: t?.aiAutoTitle, tabColor: t?.tabColor, customTitle: t?.customTitle, wsl: t?.wsl, wslDistro: t?.wslDistro }, x: p.x, y: p.y, width: p.width, height: p.height };
       }),
     };
     _sessionExtras = data;
@@ -1734,7 +1882,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
 
     // New tree format
     if (session.tree || session.floating) {
-      async function createTerm(info: { title: string; shellProfileId: string; cwd: string; startupCommand?: string; aiSessionId?: string; aiAutoTitle?: boolean; tabColor?: string; customTitle?: boolean }): Promise<{ id: TerminalId; instance: TerminalInstance } | null> {
+      async function createTerm(info: { title: string; shellProfileId: string; cwd: string; startupCommand?: string; aiSessionId?: string; aiAutoTitle?: boolean; tabColor?: string; customTitle?: boolean; wsl?: boolean; wslDistro?: string }): Promise<{ id: TerminalId; instance: TerminalInstance } | null> {
         const profile = config!.shells.find((s) => s.id === info.shellProfileId) ?? config!.shells[0];
         if (!profile) return null;
         const id = uuidv4();
@@ -1746,8 +1894,9 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
         try {
           const { pid } = await window.terminalAPI.createPty({
             id, shellPath: profile.path, args: profile.args, cwd, env: profile.env, cols: 80, rows: 24,
+            wslDistro: info.wsl ? info.wslDistro : undefined,
           });
-          return { id, instance: { id, title: info.title || profile.name, customTitle: info.customTitle ?? !!info.title, shellProfileId: profile.id, cwd, mode: 'tiled' as const, pid, lastProcess: '', startupCommand: info.startupCommand || '', aiSessionId: info.aiSessionId, aiAutoTitle: info.aiAutoTitle, tabColor: info.tabColor } };
+          return { id, instance: { id, title: info.title || profile.name, customTitle: info.customTitle ?? !!info.title, shellProfileId: profile.id, cwd, mode: 'tiled' as const, pid, lastProcess: '', startupCommand: info.startupCommand || '', aiSessionId: info.aiSessionId, aiAutoTitle: info.aiAutoTitle, tabColor: info.tabColor, wsl: info.wsl, wslDistro: info.wslDistro } };
         } catch { return null; }
       }
 
@@ -1857,91 +2006,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   },
 
   openCopilotSession: async (sessionId: string) => {
-    // If a terminal with this session is already open, just focus it
-    const { terminals: existingTerminals } = get();
-    for (const [id, inst] of existingTerminals) {
-      if (inst.aiSessionId === sessionId) {
-        set({ focusedTerminalId: id });
-        return;
-      }
-    }
-
-    const session = await (window.terminalAPI as any).getCopilotSession(sessionId);
-    if (!session) return;
-
-    const cwd = session.workspace?.cwd || undefined;
-    const store = get();
-
-    // Create a new terminal at the session's cwd
-    const config = store.config;
-    if (!config) return;
-
-    const profileId = config.defaultShellId;
-    const profile = config.shells.find((s) => s.id === profileId);
-    if (!profile) return;
-
-    const id = uuidv4();
-    const termCwd = cwd || profile.cwd || (navigator.platform.startsWith('Win') ? 'C:\\Users' : '/');
-    const { pid } = await window.terminalAPI.createPty({
-      id,
-      shellPath: profile.path,
-      args: profile.args,
-      cwd: termCwd,
-      env: profile.env,
-      cols: 80,
-      rows: 24,
-    });
-
-    const displayName = session.workspace?.summary
-      || (session.workspace?.repository ? session.workspace.repository.split('/').pop() : null)
-      || session.workspace?.name
-      || sessionId.slice(0, 8);
-    const title = displayName;
-
-    const instance: TerminalInstance = {
-      id,
-      title,
-      shellProfileId: profileId,
-      cwd: termCwd,
-      customTitle: true,
-      aiAutoTitle: true,
-      mode: 'tiled',
-      pid,
-      lastProcess: '',
-      startupCommand: `${config.copilotCommand || 'agency copilot'} --resume ${sessionId}`,
-      aiSessionId: sessionId,
-    };
-
-    const { terminals, layout } = get();
-    const newTerminals = new Map(terminals);
-    newTerminals.set(id, instance);
-    const newLeaf: LayoutLeafNode = { kind: 'leaf', terminalId: id };
-    let newRoot: LayoutNode;
-    if (layout.tilingRoot === null) {
-      newRoot = newLeaf;
-    } else {
-      const order = getLeafOrder(layout.tilingRoot);
-      newRoot = insertLeaf(layout.tilingRoot, order[order.length - 1], id, 'right');
-    }
-
-    // In grid mode, also update preGridRoot and rebuild the grid
-    const { viewMode, preGridRoot, gridColumns } = get();
-    let newPreGridRoot = preGridRoot;
-    if (viewMode === 'grid') {
-      if (preGridRoot) {
-        const preOrder = getLeafOrder(preGridRoot);
-        newPreGridRoot = insertLeaf(preGridRoot, preOrder[preOrder.length - 1], id, 'right');
-      }
-      const allIds = getLeafOrder(newRoot);
-      newRoot = buildGridTree(allIds, gridColumns || undefined) || newRoot;
-    }
-
-    set({
-      terminals: newTerminals,
-      layout: { ...layout, tilingRoot: newRoot },
-      focusedTerminalId: id,
-      preGridRoot: newPreGridRoot,
-    });
+    await openAiSession(sessionId, 'copilot', get, set);
   },
 
   setCopilotSessions: (sessions: CopilotSessionSummary[]) => {
@@ -2049,86 +2114,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   },
 
   openClaudeCodeSession: async (sessionId: string) => {
-    // If a terminal with this session is already open, just focus it
-    const { terminals: existingTerminals } = get();
-    for (const [id, inst] of existingTerminals) {
-      if (inst.aiSessionId === sessionId) {
-        set({ focusedTerminalId: id });
-        return;
-      }
-    }
-
-    const session = await (window.terminalAPI as any).getClaudeCodeSession(sessionId);
-    if (!session) return;
-
-    const cwd = session.cwd || undefined;
-    const store = get();
-    const config = store.config;
-    if (!config) return;
-
-    const profileId = config.defaultShellId;
-    const profile = config.shells.find((s: any) => s.id === profileId);
-    if (!profile) return;
-
-    const id = uuidv4();
-    const termCwd = cwd || profile.cwd || (navigator.platform.startsWith('Win') ? 'C:\\Users' : '/');
-    const { pid } = await window.terminalAPI.createPty({
-      id,
-      shellPath: profile.path,
-      args: profile.args,
-      cwd: termCwd,
-      env: profile.env,
-      cols: 80,
-      rows: 24,
-    });
-
-    const displayName = session.summary || sessionId.slice(0, 8);
-    const title = displayName;
-
-    const instance: TerminalInstance = {
-      id,
-      title,
-      shellProfileId: profileId,
-      cwd: termCwd,
-      customTitle: true,
-      aiAutoTitle: true,
-      mode: 'tiled',
-      pid,
-      lastProcess: '',
-      startupCommand: `${config.claudeCodeCommand || 'claude'} --resume ${sessionId}`,
-      aiSessionId: sessionId,
-    };
-
-    const { terminals, layout } = get();
-    const newTerminals = new Map(terminals);
-    newTerminals.set(id, instance);
-    const newLeaf: LayoutLeafNode = { kind: 'leaf', terminalId: id };
-    let newRoot: LayoutNode;
-    if (layout.tilingRoot === null) {
-      newRoot = newLeaf;
-    } else {
-      const order = getLeafOrder(layout.tilingRoot);
-      newRoot = insertLeaf(layout.tilingRoot, order[order.length - 1], id, 'right');
-    }
-
-    // In grid mode, also update preGridRoot and rebuild the grid
-    const { viewMode, preGridRoot, gridColumns } = get();
-    let newPreGridRoot = preGridRoot;
-    if (viewMode === 'grid') {
-      if (preGridRoot) {
-        const preOrder = getLeafOrder(preGridRoot);
-        newPreGridRoot = insertLeaf(preGridRoot, preOrder[preOrder.length - 1], id, 'right');
-      }
-      const allIds = getLeafOrder(newRoot);
-      newRoot = buildGridTree(allIds, gridColumns || undefined) || newRoot;
-    }
-
-    set({
-      terminals: newTerminals,
-      layout: { ...layout, tilingRoot: newRoot },
-      focusedTerminalId: id,
-      preGridRoot: newPreGridRoot,
-    });
+    await openAiSession(sessionId, 'claude-code', get, set);
   },
 
   addClaudeCodeSession: (session: CopilotSessionSummary) => {
@@ -2153,19 +2139,19 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
 
   resumeAllSessions: () => {
     const { terminals, config, copilotSessions, claudeCodeSessions } = get();
+    if (!config) return;
     for (const [id, t] of terminals) {
-      // Skip terminals that already have a running process (not just a shell prompt)
       if (!t.aiSessionId && !t.startupCommand) continue;
-      // Determine the resume command
       let cmd = t.startupCommand;
       if (!cmd && t.aiSessionId) {
+        if (!validateSessionId(t.aiSessionId)) continue;
         const isCopilot = copilotSessions.some((s) => s.id === t.aiSessionId);
         if (isCopilot) {
-          cmd = `${config?.copilotCommand || 'agency copilot'} --resume ${t.aiSessionId}`;
+          cmd = buildResumeCommand(config, 'copilot', t.aiSessionId);
         } else {
           const isClaude = claudeCodeSessions.some((s) => s.id === t.aiSessionId);
           if (isClaude) {
-            cmd = `${config?.claudeCodeCommand || 'claude'} --resume ${t.aiSessionId}`;
+            cmd = buildResumeCommand(config, 'claude-code', t.aiSessionId);
           }
         }
       }

--- a/src/renderer/state/types.ts
+++ b/src/renderer/state/types.ts
@@ -58,6 +58,8 @@ export interface TerminalInstance {
   aiSessionId?: string;
   aiAutoTitle?: boolean;
   groupId?: string;
+  wsl?: boolean;
+  wslDistro?: string;
 }
 
 export interface TabGroup {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -2866,6 +2866,17 @@ select.settings-input {
   flex-shrink: 0;
 }
 
+.ai-wsl-badge {
+  font-size: 9px;
+  padding: 0 4px;
+  border-radius: 3px;
+  color: #f9e2af;
+  background: rgba(249, 226, 175, 0.15);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+}
+
 .ai-session-time {
   font-size: 10px;
   color: var(--text-secondary);

--- a/src/shared/copilot-types.ts
+++ b/src/shared/copilot-types.ts
@@ -19,6 +19,8 @@ export interface CopilotSessionSummary {
   toolCallCount: number;
   lastActivityTime: number;
   model?: string;
+  wsl?: boolean;
+  wslDistro?: string;
 }
 
 export interface CopilotWorkspaceMetadata {


### PR DESCRIPTION
What
 
Adds WSL support to tmax so that AI sessions (Copilot & Claude Code) running inside WSL distros are discoverable, resumable, and fully integrated alongside native Windows sessions.


Why
 
Users running Claude/Copilot inside WSL couldn't see or resume those sessions from tmax — only native Windows sessions appeared. Since the app already supports Linux, this leverages the existing session monitors by pointing them at WSL filesystem
paths via \\wsl.localhost.


Changes 
 
 - Session discovery: Scans each WSL distro's ~/.claude/projects and ~/.copilot/session-state via UNC paths
 - Session panel: WSL sessions appear with a distro badge (e.g., "Ubuntu"); clicking resumes in a wsl.exe terminal at the correct directory
 - File explorer: Browses WSL filesystems when a WSL terminal is focused
 - Directories panel: WSL Linux paths work in favorites/recents
 - Save/restore: WSL terminal identity persists across app restarts
 
 New files

 - src/main/wsl-utils.ts — WSL distro detection, UNC path construction
 - src/main/wsl-session-manager.ts — orchestrates monitor/watcher pairs per distro
 
Testing
 
Tested manually on Windows 11 with Ubuntu WSL distro — session discovery, resume, file explorer, directory panel, and save/restore all verified