### PR TITLE
fix: eliminate terminal text flicker when switching tabs in focus mode

### DIFF
--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -647,9 +647,23 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
     try {
       if (isFocused && !anyOverlayOpen && terminalRef.current) {
         terminalRef.current.focus();
+        // Immediately refit in case the container size changed (e.g. focus
+        // mode shows this pane at full size while it was previously hidden at
+        // its split-ratio size).  Using rAF so the DOM layout has settled.
+        if (fitAddonRef.current) {
+          requestAnimationFrame(() => {
+            try {
+              fitAddonRef.current?.fit();
+              if (terminalRef.current) {
+                const { cols, rows } = terminalRef.current;
+                window.terminalAPI.resizePty(terminalId, cols, rows);
+              }
+            } catch { /* terminal may be disposed */ }
+          });
+        }
       }
     } catch { /* terminal may be disposed */ }
-  }, [isFocused, anyOverlayOpen]);
+  }, [isFocused, anyOverlayOpen, terminalId]);
 
   // Re-focus xterm when the OS window regains focus (alt-tab back)
   useEffect(() => {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -920,23 +920,29 @@ html.transparency-active .input-dialog {
 }
 
 /* Hide all panes except the focused one — without unmounting TerminalPanel.
-   Use visibility (not display) so child elements can override it. */
+   Use visibility (not display) so child elements can override it.
+   All tiling-leaves are positioned absolute at full size so xterm is always
+   fitted to the full container — switching focus only toggles visibility,
+   avoiding the brief text-shrink caused by refitting from a split-ratio size. */
 .tiling-focus-mode {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.tiling-focus-mode .split-container,
+.tiling-focus-mode .split-container {
+  visibility: hidden;
+}
+
 .tiling-focus-mode .tiling-leaf {
+  position: absolute;
+  inset: 0;
   visibility: hidden;
 }
 
 .tiling-focus-mode .tiling-leaf:has(.terminal-panel.focused) {
   visibility: visible;
   display: flex;
-  position: absolute;
-  inset: 0;
   z-index: 10;
 }
 


### PR DESCRIPTION
## Problem
When switching tabs in focus mode, terminal text would shrink briefly before snapping back to normal size. This happened because hidden panes were rendered at their split-ratio size, and switching focus triggered a slow refit (100ms debounce ResizeObserver).

## Solution
**CSS fix** (\global.css\): Make all \.tiling-leaf\ elements \position: absolute; inset: 0\ in focus mode — not just the focused one. Every terminal is now always fitted to full container size. Switching focus only toggles \isibility\, so there's zero size change and no refit needed.

**JS safety net** (\TerminalPanel.tsx\): Added immediate \itAddon.fit()\ + \esizePty()\ via \equestAnimationFrame\ when a terminal gains focus, as defense-in-depth.

## Files Changed
- \src/renderer/styles/global.css\ — focus mode CSS rules
- \src/renderer/components/TerminalPanel.tsx\ — immediate fit on focus gain