### PR TITLE
feat: seamless auto-updates on Windows, macOS, and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,15 +80,31 @@ jobs:
         run: |
           codesign --force --deep --sign - out/tmax-darwin-${{ matrix.arch }}/tmax.app
 
-      # Rename Windows setup exe to include architecture
-      - name: Rename Windows installer
+      # Rename Windows Squirrel artifacts to include architecture
+      - name: Rename Windows installer and Squirrel artifacts
         if: matrix.platform == 'win32'
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          for f in out/make/squirrel.windows/${{ matrix.arch }}/*.exe; do
-            mv "$f" "$(dirname "$f")/tmax-${VERSION}-${{ matrix.arch }}-Setup.exe"
+          SQDIR="out/make/squirrel.windows/${{ matrix.arch }}"
+
+          # Rename Setup.exe to include arch
+          for f in "$SQDIR"/*.exe; do
+            mv "$f" "$SQDIR/tmax-${VERSION}-${{ matrix.arch }}-Setup.exe"
           done
+
+          # Rename nupkg to include arch (e.g. tmax-1.4.8-x64-full.nupkg)
+          for f in "$SQDIR"/*.nupkg; do
+            base=$(basename "$f")
+            newname=$(echo "$base" | sed "s/-full\.nupkg/-${{ matrix.arch }}-full.nupkg/")
+            mv "$f" "$SQDIR/$newname"
+          done
+
+          # Rewrite RELEASES file entries to match renamed nupkg, then rename it
+          if [ -f "$SQDIR/RELEASES" ]; then
+            sed -i "s/-full\.nupkg/-${{ matrix.arch }}-full.nupkg/g" "$SQDIR/RELEASES"
+            mv "$SQDIR/RELEASES" "$SQDIR/RELEASES-${{ matrix.arch }}"
+          fi
 
       # Create portable ZIP for Windows
       - name: Create Windows portable ZIP
@@ -108,7 +124,7 @@ jobs:
             out/make/**/*.deb
             out/make/**/*.rpm
             out/make/**/*.nupkg
-            out/make/**/RELEASES
+            out/make/**/RELEASES*
             out/*.zip
           if-no-files-found: warn
 
@@ -152,7 +168,7 @@ jobs:
             artifacts/**/*.deb
             artifacts/**/*.rpm
             artifacts/**/*.nupkg
-            artifacts/**/RELEASES
+            artifacts/**/RELEASES*
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/scripts/test-e2e-verify.js
+++ b/scripts/test-e2e-verify.js
@@ -1,0 +1,147 @@
+/**
+ * End-to-end verification script for the auto-update flow.
+ * Exercises the same logic as version-checker.ts against the local test server.
+ *
+ * Requires test-local-update.js to be running on port 9999.
+ */
+const http = require('http');
+
+const TEST_URL = process.env.TMAX_UPDATE_TEST_URL || 'http://localhost:9999';
+
+async function test() {
+  console.log('=== Auto-Update E2E Verification ===\n');
+
+  // Step 1: Fetch release (same as fetchLatestRelease)
+  console.log('1. Fetching release from:', TEST_URL + '/releases/latest');
+  const res = await fetch(TEST_URL + '/releases/latest', {
+    headers: { 'User-Agent': 'tmax-update-checker' },
+  });
+  if (!res.ok) throw new Error('Failed to fetch release: HTTP ' + res.status);
+  const release = await res.json();
+  console.log('   tag_name:', release.tag_name);
+  console.log('   assets:', release.assets.map(a => a.name).join(', '));
+
+  // Step 2: Find RELEASES and nupkg (same as checkWindowsUpdate)
+  const arch = process.arch;
+  const releasesAsset = release.assets.find(
+    a => a.name === `RELEASES-${arch}` || a.name === 'RELEASES'
+  );
+  const nupkgAsset = release.assets.find(a => a.name.endsWith('.nupkg'));
+
+  if (!releasesAsset) throw new Error('No RELEASES asset found');
+  if (!nupkgAsset) throw new Error('No nupkg asset found');
+
+  console.log('\n2. Asset resolution:');
+  console.log('   RELEASES:', releasesAsset.name, '->', releasesAsset.browser_download_url);
+  console.log('   nupkg:', nupkgAsset.name, '->', nupkgAsset.browser_download_url);
+
+  // Step 3: Download RELEASES content (same as downloadText)
+  const relRes = await fetch(releasesAsset.browser_download_url, {
+    headers: { 'User-Agent': 'tmax-update-checker' },
+    redirect: 'follow',
+  });
+  const releasesContent = await relRes.text();
+  console.log('\n3. Raw RELEASES content:');
+  console.log('   ' + releasesContent.trim());
+
+  // Step 4: Rewrite RELEASES (same logic as in checkWindowsUpdate)
+  const nupkgBaseUrl = nupkgAsset.browser_download_url.substring(
+    0, nupkgAsset.browser_download_url.lastIndexOf('/') + 1
+  );
+  const rewritten = releasesContent.split('\n').map(line => {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length >= 2) {
+      const filename = parts[1];
+      const asset = release.assets.find(a => a.name === filename);
+      if (asset) parts[1] = asset.browser_download_url;
+      else parts[1] = nupkgBaseUrl + filename;
+    }
+    return parts.join(' ');
+  }).filter(Boolean).join('\n');
+
+  console.log('\n4. Rewritten RELEASES:');
+  console.log('   ' + rewritten);
+
+  // Step 5: Start feed server (same as startFeedServer)
+  const feedServer = http.createServer((req, res) => {
+    if (req.url === '/RELEASES' || req.url === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(rewritten);
+    } else {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  });
+  await new Promise(resolve => feedServer.listen(0, '127.0.0.1', resolve));
+  const port = feedServer.address().port;
+  console.log('\n5. Feed server started on port', port);
+
+  // Step 6: Simulate Squirrel.Windows fetching /RELEASES
+  const squirrelRes = await fetch(`http://127.0.0.1:${port}/RELEASES`);
+  const squirrelContent = await squirrelRes.text();
+  console.log('\n6. Squirrel would receive:');
+  console.log('   ' + squirrelContent.trim());
+
+  // Step 7: Validate RELEASES format
+  console.log('\n7. Validating RELEASES format...');
+  const lines = squirrelContent.trim().split('\n');
+  let allPassed = true;
+
+  for (const line of lines) {
+    const parts = line.split(/\s+/);
+    if (parts.length < 3) {
+      console.log('   FAIL: line has < 3 parts:', line);
+      allPassed = false;
+      continue;
+    }
+
+    const [sha, url, size] = parts;
+
+    // Check SHA1
+    const sha1ok = /^[0-9A-Fa-f]{40}$/.test(sha);
+    console.log('   SHA1 hash:', sha1ok ? 'PASS' : 'FAIL', `(${sha.substring(0, 10)}..., length=${sha.length})`);
+    if (!sha1ok) allPassed = false;
+
+    // Check URL is absolute
+    const urlOk = url.startsWith('http://') || url.startsWith('https://');
+    console.log('   URL absolute:', urlOk ? 'PASS' : 'FAIL', `(${url.substring(0, 60)}...)`);
+    if (!urlOk) allPassed = false;
+
+    // Check size is numeric
+    const sizeOk = /^\d+$/.test(size);
+    console.log('   Size numeric:', sizeOk ? 'PASS' : 'FAIL', `(${size})`);
+    if (!sizeOk) allPassed = false;
+
+    // Check nupkg is actually downloadable
+    const headRes = await fetch(url, { method: 'HEAD' });
+    const downloadOk = headRes.status === 200;
+    const contentLen = headRes.headers.get('content-length');
+    console.log('   Downloadable:', downloadOk ? 'PASS' : 'FAIL',
+      `(HTTP ${headRes.status}, ${(parseInt(contentLen) / 1024 / 1024).toFixed(1)} MB)`);
+    if (!downloadOk) allPassed = false;
+
+    // Check size matches Content-Length
+    const sizeMatch = contentLen === size;
+    console.log('   Size matches:', sizeMatch ? 'PASS' : 'FAIL',
+      `(RELEASES=${size}, actual=${contentLen})`);
+    if (!sizeMatch) allPassed = false;
+  }
+
+  feedServer.close();
+
+  console.log('\n' + '='.repeat(50));
+  if (allPassed) {
+    console.log('ALL CHECKS PASSED');
+    console.log('Squirrel.Windows would successfully parse this RELEASES');
+    console.log('file and download the nupkg for update installation.');
+  } else {
+    console.log('SOME CHECKS FAILED');
+    process.exit(1);
+  }
+  console.log('='.repeat(50));
+}
+
+test().catch(e => {
+  console.error('\nFATAL:', e.message);
+  process.exit(1);
+});

--- a/scripts/test-local-update.js
+++ b/scripts/test-local-update.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Local Update Test Server
+ *
+ * Simulates GitHub's release API so you can test the full Squirrel update flow
+ * without pushing to CI.
+ *
+ * Usage:
+ *   1. Build the current version:  npm run build   (produces v1.4.8 installer)
+ *   2. Install it via the Setup.exe
+ *   3. Bump version in package.json to 1.4.9 (or higher)
+ *   4. Rebuild:  npm run build
+ *   5. Run this script:  node scripts/test-local-update.js
+ *   6. Launch the INSTALLED (old) version with:
+ *        set TMAX_UPDATE_TEST_URL=http://localhost:9999
+ *        "C:\Users\<you>\AppData\Local\tmax\tmax.exe"
+ *   7. Watch DevTools console (Ctrl+Shift+I) for [update] logs
+ *
+ * What this does:
+ *   - Scans out/make/squirrel.windows/ for RELEASES + .nupkg files
+ *   - Serves a fake /releases/latest JSON (mimicking GitHub API)
+ *   - Serves the actual RELEASES file and nupkg for Squirrel to download
+ */
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = 9999;
+
+// Find Squirrel output
+function findSquirrelOutput() {
+  const baseDir = path.join(__dirname, '..', 'out', 'make', 'squirrel.windows');
+  if (!fs.existsSync(baseDir)) {
+    console.error(`ERROR: ${baseDir} not found. Run "npm run build" first.`);
+    process.exit(1);
+  }
+
+  // Find the arch subfolder (x64 or arm64)
+  const archDirs = fs.readdirSync(baseDir).filter(d =>
+    fs.statSync(path.join(baseDir, d)).isDirectory()
+  );
+
+  if (archDirs.length === 0) {
+    console.error(`ERROR: No architecture folders found in ${baseDir}`);
+    process.exit(1);
+  }
+
+  const archDir = path.join(baseDir, archDirs[0]);
+  console.log(`Found Squirrel output in: ${archDir}`);
+
+  // Find RELEASES file
+  const releasesPath = fs.readdirSync(archDir).find(f => f === 'RELEASES');
+  if (!releasesPath) {
+    console.error(`ERROR: No RELEASES file found in ${archDir}`);
+    process.exit(1);
+  }
+
+  // Find nupkg file
+  const nupkgFile = fs.readdirSync(archDir).find(f => f.endsWith('.nupkg'));
+  if (!nupkgFile) {
+    console.error(`ERROR: No .nupkg file found in ${archDir}`);
+    process.exit(1);
+  }
+
+  // Find Setup exe to determine version
+  const setupFile = fs.readdirSync(archDir).find(f => f.endsWith('Setup.exe'));
+
+  const releasesContent = fs.readFileSync(path.join(archDir, 'RELEASES'), 'utf8');
+  const nupkgPath = path.join(archDir, nupkgFile);
+  const nupkgSize = fs.statSync(nupkgPath).size;
+
+  // Extract version from nupkg filename (e.g., tmax-1.4.9-full.nupkg)
+  const versionMatch = nupkgFile.match(/(\d+\.\d+\.\d+)/);
+  const version = versionMatch ? versionMatch[1] : '0.0.0';
+
+  return {
+    archDir,
+    releasesContent,
+    nupkgFile,
+    nupkgPath,
+    nupkgSize,
+    version,
+    setupFile,
+  };
+}
+
+const sq = findSquirrelOutput();
+console.log(`\nServing update for version: v${sq.version}`);
+console.log(`  RELEASES: ${sq.releasesContent.trim()}`);
+console.log(`  nupkg: ${sq.nupkgFile} (${(sq.nupkgSize / 1024 / 1024).toFixed(1)} MB)`);
+
+// Build the fake GitHub release JSON
+const baseUrl = `http://localhost:${PORT}`;
+const fakeRelease = {
+  tag_name: `v${sq.version}`,
+  html_url: `${baseUrl}/release`,
+  body: `Test release v${sq.version} served from local build`,
+  assets: [
+    {
+      name: 'RELEASES',
+      browser_download_url: `${baseUrl}/download/RELEASES`,
+    },
+    {
+      name: sq.nupkgFile,
+      browser_download_url: `${baseUrl}/download/${sq.nupkgFile}`,
+    },
+  ],
+};
+
+// Rewrite RELEASES content so filenames point to our local download URLs
+const rewrittenReleases = sq.releasesContent.split('\n').map(line => {
+  const parts = line.trim().split(/\s+/);
+  if (parts.length >= 2) {
+    const filename = parts[1];
+    const asset = fakeRelease.assets.find(a => a.name === filename);
+    if (asset) {
+      parts[1] = asset.browser_download_url;
+    }
+  }
+  return parts.join(' ');
+}).filter(Boolean).join('\n');
+
+console.log(`\nRewritten RELEASES content:\n  ${rewrittenReleases}`);
+
+const server = http.createServer((req, res) => {
+  const url = req.url;
+  console.log(`[${new Date().toISOString()}] ${req.method} ${url}`);
+
+  // GitHub API: /releases/latest
+  if (url === '/releases/latest') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(fakeRelease));
+    console.log('  -> Served fake release JSON');
+    return;
+  }
+
+  // RELEASES file
+  if (url === '/download/RELEASES') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(sq.releasesContent);
+    console.log('  -> Served RELEASES file');
+    return;
+  }
+
+  // nupkg file
+  if (url === `/download/${sq.nupkgFile}`) {
+    const stat = fs.statSync(sq.nupkgPath);
+    res.writeHead(200, {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': stat.size,
+    });
+    const stream = fs.createReadStream(sq.nupkgPath);
+    stream.pipe(res);
+    console.log(`  -> Streaming nupkg (${(stat.size / 1024 / 1024).toFixed(1)} MB)`);
+    return;
+  }
+
+  // 404 for anything else
+  res.writeHead(404);
+  res.end('Not found');
+  console.log('  -> 404');
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`Update test server running on http://localhost:${PORT}`);
+  console.log(`${'='.repeat(60)}`);
+  console.log(`\nTo test, launch the INSTALLED (older) version with:`);
+  console.log(`\n  PowerShell:`);
+  console.log(`    $env:TMAX_UPDATE_TEST_URL="http://localhost:${PORT}"; & "$env:LOCALAPPDATA\\tmax\\tmax.exe"`);
+  console.log(`\n  CMD:`);
+  console.log(`    set TMAX_UPDATE_TEST_URL=http://localhost:${PORT} && "%LOCALAPPDATA%\\tmax\\tmax.exe"`);
+  console.log(`\nThen open DevTools (Ctrl+Shift+I) and watch for [update] logs.`);
+  console.log(`The app should detect v${sq.version} and offer to update.\n`);
+  console.log('Press Ctrl+C to stop.\n');
+});

--- a/src/main/version-checker.ts
+++ b/src/main/version-checker.ts
@@ -1,13 +1,17 @@
-import { app, autoUpdater, Notification, BrowserWindow } from 'electron';
+import { app, autoUpdater, Notification, BrowserWindow, shell } from 'electron';
 import Store from 'electron-store';
-import { createServer } from 'http';
+import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { IPC } from '../shared/ipc-channels';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import https from 'node:https';
 
 const GITHUB_REPO = 'InbarR/tmax';
 const UPDATE_SERVER = 'https://update.electronjs.org';
 const GITHUB_RELEASES_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
-const INITIAL_DELAY_MS = 5000;
+const INITIAL_DELAY_MS = 10_000; // 10s — avoid first-run lock issues
 
 export type UpdateStatus = 'idle' | 'checking' | 'downloading' | 'downloaded' | 'available' | 'error';
 
@@ -20,6 +24,18 @@ export interface UpdateInfo {
   releaseNotes?: string;
 }
 
+interface GitHubAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  html_url: string;
+  body?: string;
+  assets: GitHubAsset[];
+}
+
 export class VersionChecker {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -27,6 +43,9 @@ export class VersionChecker {
   private updateInfo: UpdateInfo;
   private supportsAutoUpdate: boolean;
   private versionStore = new Store({ name: 'tmax-version-check' });
+  private feedServer: Server | null = null;
+  // Track pending Linux download so we can call restartAndUpdate later
+  private linuxPackagePath: string | null = null;
 
   constructor(mainWindow: BrowserWindow) {
     this.mainWindow = mainWindow;
@@ -34,7 +53,7 @@ export class VersionChecker {
       status: 'idle',
       current: app.getVersion(),
     };
-    // Auto-update works on packaged Windows/macOS builds only
+    // Native auto-update (Squirrel) on packaged Windows/macOS only
     this.supportsAutoUpdate = app.isPackaged &&
       (process.platform === 'win32' || process.platform === 'darwin');
   }
@@ -42,6 +61,8 @@ export class VersionChecker {
   start(): void {
     if (this.supportsAutoUpdate) {
       this.setupAutoUpdater();
+    } else if (process.platform === 'linux' && app.isPackaged) {
+      this.setupLinuxUpdater();
     } else {
       this.setupGitHubPolling();
     }
@@ -50,6 +71,7 @@ export class VersionChecker {
   stop(): void {
     if (this.timeoutId) clearTimeout(this.timeoutId);
     if (this.intervalId) clearInterval(this.intervalId);
+    this.closeFeedServer();
   }
 
   getUpdateInfo(): UpdateInfo {
@@ -61,8 +83,10 @@ export class VersionChecker {
       if (process.platform === 'win32') {
         this.checkWindowsUpdate();
       } else {
-        autoUpdater.checkForUpdates();
+        this.checkMacUpdate();
       }
+    } else if (process.platform === 'linux' && app.isPackaged) {
+      this.checkLinuxUpdate();
     } else {
       this.checkGitHub();
     }
@@ -71,24 +95,32 @@ export class VersionChecker {
   restartAndUpdate(): void {
     if (this.supportsAutoUpdate && this.updateInfo.status === 'downloaded') {
       autoUpdater.quitAndInstall();
+    } else if (process.platform === 'linux' && this.linuxPackagePath) {
+      // On Linux, open the folder containing the downloaded package
+      shell.showItemInFolder(this.linuxPackagePath);
     }
   }
 
+  // ── Auto-updater setup (Windows + macOS) ──────────────────────────────
+
   private setupAutoUpdater(): void {
-    // Register autoUpdater event handlers (common for all platforms)
     autoUpdater.on('checking-for-update', () => {
+      console.log('[update] Squirrel: checking-for-update');
       this.setStatus('checking');
     });
 
     autoUpdater.on('update-available', () => {
+      console.log('[update] Squirrel: update-available');
       this.setStatus('downloading');
     });
 
     autoUpdater.on('update-not-available', () => {
+      console.log('[update] Squirrel: update-not-available');
       this.setStatus('idle');
     });
 
     autoUpdater.on('update-downloaded', async (_event, _releaseNotes, releaseName) => {
+      console.log('[update] Squirrel: update-downloaded, releaseName:', releaseName);
       const version = (releaseName || '').replace(/^v/, '') || undefined;
       const releaseNotes = await this.fetchReleaseNotes();
       this.updateInfo = {
@@ -98,110 +130,312 @@ export class VersionChecker {
         releaseNotes,
       };
       this.broadcastUpdate();
-
-      // Show native notification once
-      const lastNotified = this.versionStore.get('lastNotifiedVersion', '') as string;
-      if (version && lastNotified !== version && Notification.isSupported()) {
-        const notification = new Notification({
-          title: 'tmax Update Ready',
-          body: `Version ${version} downloaded. Restart to apply.`,
-        });
-        notification.show();
-        this.versionStore.set('lastNotifiedVersion', version);
-      }
+      this.closeFeedServer();
+      this.showNotification('tmax Update Ready', `Version ${version} downloaded. Restart to apply.`, version);
     });
 
     autoUpdater.on('error', (err: Error) => {
       console.error('Auto-update error:', err.message);
-      this.updateInfo = {
-        ...this.updateInfo,
-        status: 'error',
-        error: err.message,
-      };
+      this.updateInfo = { ...this.updateInfo, status: 'error', error: err.message };
       this.broadcastUpdate();
-      // Fall back to GitHub API to at least show the available version
-      this.checkGitHub();
+      this.closeFeedServer();
+      // On macOS, try the GitHub API fallback before giving up to manual download
+      if (process.platform === 'darwin') {
+        this.checkMacUpdateFallback();
+      } else {
+        this.checkGitHub();
+      }
     });
 
     if (process.platform === 'win32') {
-      // On Windows, update.electronjs.org returns Setup.exe instead of .nupkg
-      // because the nupkg filename lacks an architecture qualifier. This breaks
-      // Squirrel auto-update. Bypass the update server and resolve the nupkg
-      // URL directly from the GitHub release assets.
       this.timeoutId = setTimeout(() => {
         this.checkWindowsUpdate();
         this.intervalId = setInterval(() => this.checkWindowsUpdate(), CHECK_INTERVAL_MS);
       }, INITIAL_DELAY_MS);
     } else {
-      // macOS: update.electronjs.org correctly returns .zip files
-      const feedURL = `${UPDATE_SERVER}/${GITHUB_REPO}/${process.platform}-${process.arch}/${app.getVersion()}`;
-      try {
-        autoUpdater.setFeedURL({ url: feedURL });
-      } catch (err) {
-        console.error('Failed to set auto-update feed URL:', err);
-        this.supportsAutoUpdate = false;
-        this.setupGitHubPolling();
-        return;
-      }
+      // macOS
       this.timeoutId = setTimeout(() => {
-        autoUpdater.checkForUpdates();
-        this.intervalId = setInterval(() => autoUpdater.checkForUpdates(), CHECK_INTERVAL_MS);
+        this.checkMacUpdate();
+        this.intervalId = setInterval(() => this.checkMacUpdate(), CHECK_INTERVAL_MS);
       }, INITIAL_DELAY_MS);
     }
   }
 
-  // Windows auto-update: fetch the latest release from GitHub, find the .nupkg
-  // asset URL, and serve it to Squirrel via a one-shot local HTTP server.
+  // ── Windows: Squirrel update via proper RELEASES file ─────────────────
+
   private async checkWindowsUpdate(): Promise<void> {
     try {
-      const res = await fetch(GITHUB_RELEASES_URL, {
-        headers: { 'User-Agent': 'tmax-update-checker' },
-      });
-      if (!res.ok) return;
+      this.setStatus('checking');
+      const release = await this.fetchLatestRelease();
+      if (!release) return this.setStatus('idle');
 
-      const data = await res.json();
-      const tagName: string = data.tag_name;
-      if (this.compareVersions(tagName, app.getVersion()) <= 0) return;
+      const tagName = release.tag_name;
+      console.log(`[update] Windows: latest release ${tagName}, current ${app.getVersion()}`);
+      if (this.compareVersions(tagName, app.getVersion()) <= 0) {
+        this.setStatus('idle');
+        return;
+      }
 
-      // Find the .nupkg asset — Squirrel needs this for auto-update
-      const nupkgAsset = (data.assets as { name: string; browser_download_url: string }[])
-        ?.find((a) => a.name.endsWith('.nupkg'));
-      if (!nupkgAsset) {
+      // Find arch-specific RELEASES file (e.g. RELEASES-x64)
+      const arch = process.arch; // x64 or arm64
+      const releasesAsset = release.assets.find(
+        (a) => a.name === `RELEASES-${arch}` || a.name === 'RELEASES'
+      );
+      // Find arch-specific nupkg
+      const nupkgAsset = release.assets.find(
+        (a) => a.name.endsWith('.nupkg') && (a.name.includes(arch) || !release.assets.some(b => b.name.includes(arch) && b.name.endsWith('.nupkg')))
+      );
+
+      console.log(`[update] Windows: RELEASES asset=${releasesAsset?.name}, nupkg=${nupkgAsset?.name}`);
+
+      if (!releasesAsset || !nupkgAsset) {
+        console.warn('[update] Squirrel artifacts not found in release, falling back to GitHub polling');
         this.checkGitHub();
         return;
       }
 
-      // Squirrel expects the feed URL to return JSON: { url, name, notes }
-      // Create a one-shot local server that returns the correct nupkg URL
-      const server = createServer((_req, resp) => {
-        resp.writeHead(200, { 'Content-Type': 'application/json' });
-        resp.end(JSON.stringify({
-          url: nupkgAsset.browser_download_url,
-          name: tagName,
-          notes: data.body || '',
-        }));
-        setTimeout(() => server.close(), 1000);
-      });
+      // Download the RELEASES file content
+      const releasesContent = await this.downloadText(releasesAsset.browser_download_url);
+      if (!releasesContent) {
+        console.warn('[update] Failed to download RELEASES file');
+        this.checkGitHub();
+        return;
+      }
+      console.log(`[update] Windows: raw RELEASES content: ${releasesContent.trim()}`);
 
-      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-      const addr = server.address();
+      // Rewrite nupkg references in RELEASES to full GitHub download URLs
+      // RELEASES format: <sha> <filename> <size>
+      const nupkgBaseUrl = nupkgAsset.browser_download_url.substring(
+        0, nupkgAsset.browser_download_url.lastIndexOf('/') + 1
+      );
+      const rewrittenReleases = releasesContent.split('\n').map((line) => {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length >= 2) {
+          const filename = parts[1];
+          // Find the matching asset URL for this nupkg filename
+          const asset = release.assets.find((a) => a.name === filename);
+          if (asset) {
+            parts[1] = asset.browser_download_url;
+          } else {
+            // Fallback: construct URL from base
+            parts[1] = nupkgBaseUrl + filename;
+          }
+        }
+        return parts.join(' ');
+      }).filter(Boolean).join('\n');
+
+      console.log(`[update] Windows: rewritten RELEASES: ${rewrittenReleases.trim()}`);
+
+      // Start (or reuse) local HTTP server to serve the RELEASES file
+      await this.startFeedServer(rewrittenReleases);
+
+      const addr = this.feedServer!.address();
       const port = typeof addr === 'object' && addr ? addr.port : 0;
       if (!port) {
-        server.close();
+        this.closeFeedServer();
         this.checkGitHub();
         return;
       }
 
-      // Close the server if autoUpdater doesn't request within 30s
-      const safetyTimer = setTimeout(() => server.close(), 30_000);
-      server.on('close', () => clearTimeout(safetyTimer));
-
+      console.log(`[update] Windows: feed server on port ${port}, calling autoUpdater.checkForUpdates()`);
       autoUpdater.setFeedURL({ url: `http://127.0.0.1:${port}` });
       autoUpdater.checkForUpdates();
-    } catch {
+    } catch (err) {
+      console.error('[update] Windows update check failed:', err);
       this.checkGitHub();
     }
   }
+
+  /**
+   * Start a local HTTP server that serves the Squirrel RELEASES file.
+   * Squirrel.Windows fetches `{feedURL}/RELEASES` and then downloads
+   * nupkg files from the URLs listed inside.
+   */
+  private async startFeedServer(releasesContent: string): Promise<void> {
+    this.closeFeedServer();
+
+    this.feedServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+      console.log(`[update] Feed server request: ${req.method} ${req.url}`);
+      // Squirrel requests /RELEASES (or just /)
+      if (req.url === '/RELEASES' || req.url === '/') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(releasesContent);
+      } else {
+        res.writeHead(404);
+        res.end('Not found');
+      }
+    });
+
+    await new Promise<void>((resolve) => this.feedServer!.listen(0, '127.0.0.1', resolve));
+
+    // Auto-close after 60s if Squirrel doesn't complete
+    const safetyTimer = setTimeout(() => this.closeFeedServer(), 60_000);
+    this.feedServer.on('close', () => clearTimeout(safetyTimer));
+  }
+
+  private closeFeedServer(): void {
+    if (this.feedServer) {
+      try { this.feedServer.close(); } catch { /* ignore */ }
+      this.feedServer = null;
+    }
+  }
+
+  // ── macOS: update.electronjs.org with GitHub API fallback ─────────────
+
+  private async checkMacUpdate(): Promise<void> {
+    const feedURL = `${UPDATE_SERVER}/${GITHUB_REPO}/${process.platform}-${process.arch}/${app.getVersion()}`;
+    try {
+      autoUpdater.setFeedURL({ url: feedURL });
+      autoUpdater.checkForUpdates();
+    } catch (err) {
+      console.error('macOS auto-update via update.electronjs.org failed:', err);
+      // Fallback: use GitHub API to find the .zip and serve a JSON feed
+      await this.checkMacUpdateFallback();
+    }
+  }
+
+  private async checkMacUpdateFallback(): Promise<void> {
+    try {
+      const release = await this.fetchLatestRelease();
+      if (!release) return;
+
+      const tagName = release.tag_name;
+      if (this.compareVersions(tagName, app.getVersion()) <= 0) return;
+
+      // Find the macOS .zip asset for current architecture
+      const arch = process.arch;
+      const zipAsset = release.assets.find(
+        (a) => a.name.endsWith('.zip') && a.name.includes('darwin') && a.name.includes(arch)
+      ) || release.assets.find(
+        (a) => a.name.endsWith('.zip') && a.name.includes('darwin')
+      );
+
+      if (!zipAsset) {
+        this.checkGitHub();
+        return;
+      }
+
+      // Squirrel.Mac expects a JSON response with { url, name?, notes?, pub_date? }
+      this.closeFeedServer();
+      this.feedServer = createServer((_req: IncomingMessage, res: ServerResponse) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          url: zipAsset.browser_download_url,
+          name: tagName,
+          notes: release.body || '',
+        }));
+      });
+
+      await new Promise<void>((resolve) => this.feedServer!.listen(0, '127.0.0.1', resolve));
+      const addr = this.feedServer!.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      if (!port) {
+        this.closeFeedServer();
+        this.checkGitHub();
+        return;
+      }
+
+      const safetyTimer = setTimeout(() => this.closeFeedServer(), 60_000);
+      this.feedServer.on('close', () => clearTimeout(safetyTimer));
+
+      autoUpdater.setFeedURL({ url: `http://127.0.0.1:${port}`, serverType: 'json' as any });
+      autoUpdater.checkForUpdates();
+    } catch (err) {
+      console.error('macOS fallback update check failed:', err);
+      this.checkGitHub();
+    }
+  }
+
+  // ── Linux: download package and show in folder ────────────────────────
+
+  private setupLinuxUpdater(): void {
+    this.timeoutId = setTimeout(() => {
+      this.checkLinuxUpdate();
+      this.intervalId = setInterval(() => this.checkLinuxUpdate(), CHECK_INTERVAL_MS);
+    }, INITIAL_DELAY_MS);
+  }
+
+  private async checkLinuxUpdate(): Promise<void> {
+    try {
+      const release = await this.fetchLatestRelease();
+      if (!release) return;
+
+      const tagName = release.tag_name;
+      const currentVersion = app.getVersion();
+      if (this.compareVersions(tagName, currentVersion) <= 0) return;
+
+      const latestClean = tagName.replace(/^v/, '');
+
+      // Detect distro package type
+      const ext = this.detectLinuxPackageType();
+      const asset = release.assets.find((a) => a.name.endsWith(ext));
+
+      if (!asset) {
+        // No matching package — fall back to showing release URL
+        this.updateInfo = {
+          status: 'available',
+          current: currentVersion,
+          latest: latestClean,
+          url: release.html_url,
+          releaseNotes: release.body || undefined,
+        };
+        this.broadcastUpdate();
+        this.showNotification('tmax Update Available', `Version ${latestClean} is available`, latestClean);
+        return;
+      }
+
+      // Download the package to temp directory
+      this.setStatus('downloading');
+      this.updateInfo = { ...this.updateInfo, latest: latestClean };
+      this.broadcastUpdate();
+
+      const tmpDir = path.join(os.tmpdir(), 'tmax-update');
+      if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+      const destPath = path.join(tmpDir, asset.name);
+
+      // Skip download if already downloaded
+      if (!fs.existsSync(destPath)) {
+        await this.downloadFile(asset.browser_download_url, destPath);
+      }
+
+      this.linuxPackagePath = destPath;
+      this.updateInfo = {
+        status: 'downloaded',
+        current: currentVersion,
+        latest: latestClean,
+        url: release.html_url,
+        releaseNotes: release.body || undefined,
+      };
+      this.broadcastUpdate();
+      this.showNotification(
+        'tmax Update Downloaded',
+        `Version ${latestClean} downloaded. Click "Restart & Update" to view the package.`,
+        latestClean
+      );
+    } catch (err) {
+      console.error('Linux update check failed:', err);
+      this.checkGitHub();
+    }
+  }
+
+  private detectLinuxPackageType(): string {
+    // Check for dpkg (Debian/Ubuntu) vs rpm (Fedora/RHEL)
+    try {
+      const { execSync } = require('child_process');
+      execSync('which dpkg', { stdio: 'ignore' });
+      return '.deb';
+    } catch {
+      try {
+        const { execSync } = require('child_process');
+        execSync('which rpm', { stdio: 'ignore' });
+        return '.rpm';
+      } catch {
+        return '.deb'; // default
+      }
+    }
+  }
+
+  // ── GitHub polling fallback (dev mode or when auto-update fails) ──────
 
   private setupGitHubPolling(): void {
     this.timeoutId = setTimeout(() => {
@@ -212,15 +446,10 @@ export class VersionChecker {
 
   private async checkGitHub(): Promise<void> {
     try {
-      const res = await fetch(GITHUB_RELEASES_URL, {
-        headers: { 'User-Agent': 'tmax-update-checker' },
-      });
-      if (!res.ok) return;
+      const release = await this.fetchLatestRelease();
+      if (!release) return;
 
-      const data = await res.json();
-      const tagName: string = data.tag_name;
-      const htmlUrl: string = data.html_url;
-      const releaseNotes: string | undefined = data.body || undefined;
+      const tagName = release.tag_name;
       const currentVersion = app.getVersion();
 
       if (this.compareVersions(tagName, currentVersion) > 0) {
@@ -229,25 +458,70 @@ export class VersionChecker {
           status: 'available',
           current: currentVersion,
           latest: latestClean,
-          url: htmlUrl,
-          releaseNotes,
+          url: release.html_url,
+          releaseNotes: release.body || undefined,
         };
         this.broadcastUpdate();
-
-        // Show native notification once per new version
-        const lastNotified = this.versionStore.get('lastNotifiedVersion', '') as string;
-        if (lastNotified !== latestClean && Notification.isSupported()) {
-          const notification = new Notification({
-            title: 'tmax Update Available',
-            body: `Version ${latestClean} is available (you have ${currentVersion})`,
-          });
-          notification.show();
-          this.versionStore.set('lastNotifiedVersion', latestClean);
-        }
+        this.showNotification('tmax Update Available', `Version ${latestClean} is available (you have ${currentVersion})`, latestClean);
       }
     } catch {
       // Silently ignore network errors
     }
+  }
+
+  // ── Shared helpers ────────────────────────────────────────────────────
+
+  private async fetchLatestRelease(): Promise<GitHubRelease | null> {
+    const res = await fetch(GITHUB_RELEASES_URL, {
+      headers: { 'User-Agent': 'tmax-update-checker' },
+    });
+    if (!res.ok) return null;
+    return res.json() as Promise<GitHubRelease>;
+  }
+
+  private async fetchReleaseNotes(): Promise<string | undefined> {
+    try {
+      const release = await this.fetchLatestRelease();
+      return release?.body || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Download a text file (e.g., RELEASES) following redirects. */
+  private async downloadText(url: string): Promise<string | null> {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': 'tmax-update-checker' },
+        redirect: 'follow',
+      });
+      if (!res.ok) return null;
+      return res.text();
+    } catch {
+      return null;
+    }
+  }
+
+  /** Download a binary file to disk, following redirects. */
+  private downloadFile(url: string, destPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const doRequest = (reqUrl: string, redirectCount = 0) => {
+        if (redirectCount > 5) return reject(new Error('Too many redirects'));
+        const parsedUrl = new URL(reqUrl);
+        const mod = parsedUrl.protocol === 'https:' ? https : require('http');
+        mod.get(reqUrl, { headers: { 'User-Agent': 'tmax-update-checker' } }, (res: any) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            return doRequest(res.headers.location, redirectCount + 1);
+          }
+          if (res.statusCode !== 200) return reject(new Error(`HTTP ${res.statusCode}`));
+          const ws = fs.createWriteStream(destPath);
+          res.pipe(ws);
+          ws.on('finish', () => { ws.close(); resolve(); });
+          ws.on('error', reject);
+        }).on('error', reject);
+      };
+      doRequest(url);
+    });
   }
 
   private setStatus(status: UpdateStatus): void {
@@ -261,16 +535,13 @@ export class VersionChecker {
     }
   }
 
-  private async fetchReleaseNotes(): Promise<string | undefined> {
-    try {
-      const res = await fetch(GITHUB_RELEASES_URL, {
-        headers: { 'User-Agent': 'tmax-update-checker' },
-      });
-      if (!res.ok) return undefined;
-      const data = await res.json();
-      return data.body || undefined;
-    } catch {
-      return undefined;
+  private showNotification(title: string, body: string, version?: string): void {
+    if (!version) return;
+    const lastNotified = this.versionStore.get('lastNotifiedVersion', '') as string;
+    if (lastNotified !== version && Notification.isSupported()) {
+      const notification = new Notification({ title, body });
+      notification.show();
+      this.versionStore.set('lastNotifiedVersion', version);
     }
   }
 

--- a/src/main/version-checker.ts
+++ b/src/main/version-checker.ts
@@ -9,9 +9,12 @@ import https from 'node:https';
 
 const GITHUB_REPO = 'InbarR/tmax';
 const UPDATE_SERVER = 'https://update.electronjs.org';
-const GITHUB_RELEASES_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+// Allow overriding for local testing: set TMAX_UPDATE_TEST_URL=http://localhost:9999
+const GITHUB_RELEASES_URL = process.env.TMAX_UPDATE_TEST_URL
+  ? `${process.env.TMAX_UPDATE_TEST_URL}/releases/latest`
+  : `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
-const INITIAL_DELAY_MS = 10_000; // 10s — avoid first-run lock issues
+const INITIAL_DELAY_MS = process.env.TMAX_UPDATE_TEST_URL ? 3_000 : 10_000;
 
 export type UpdateStatus = 'idle' | 'checking' | 'downloading' | 'downloaded' | 'available' | 'error';
 
@@ -59,6 +62,9 @@ export class VersionChecker {
   }
 
   start(): void {
+    if (process.env.TMAX_UPDATE_TEST_URL) {
+      console.log(`[update] TEST MODE: using ${process.env.TMAX_UPDATE_TEST_URL} instead of GitHub API`);
+    }
     if (this.supportsAutoUpdate) {
       this.setupAutoUpdater();
     } else if (process.platform === 'linux' && app.isPackaged) {
@@ -517,7 +523,8 @@ export class VersionChecker {
           const ws = fs.createWriteStream(destPath);
           res.pipe(ws);
           ws.on('finish', () => { ws.close(); resolve(); });
-          ws.on('error', reject);
+          ws.on('error', (err: Error) => { res.destroy(); reject(err); });
+          res.on('error', (err: Error) => { ws.destroy(); reject(err); });
         }).on('error', reject);
       };
       doRequest(url);


### PR DESCRIPTION
## Summary

Auto-updates were broken on Windows — the old version-checker served JSON to Squirrel.Windows, which expects a plain-text RELEASES file. This caused silent failures that fell back to showing a manual download link.

This PR fixes auto-updates across all platforms and adds local testing infrastructure.

## Changes

### Windows (Squirrel.Windows) — the core fix
- Fetch the **RELEASES** file from GitHub release assets (not serve JSON)
- Rewrite nupkg filenames in RELEASES to full GitHub download URLs
- Serve via a local HTTP server on `/RELEASES` (Squirrel's expected endpoint)
- Squirrel downloads the nupkg, applies it, and offers "Restart & Update"

### CI/CD — architecture collision fix
- Rename nupkg to include arch suffix (e.g. `tmax-1.4.8-x64-full.nupkg`)
- Rename RELEASES to `RELEASES-x64` / `RELEASES-arm64`
- Rewrite RELEASES content to reference the renamed nupkg
- Update upload/release globs to match new names

### macOS — fallback hardening
- Keep `update.electronjs.org` as primary update source
- Add GitHub API fallback (`checkMacUpdateFallback()`) that finds darwin .zip assets and serves a JSON feed for Squirrel.Mac
- Error handler now tries fallback before showing manual download

### Linux — download + show
- Downloads matching .deb/.rpm to temp directory
- "Restart & Update" opens the folder via `shell.showItemInFolder()`
- Detects package type via `which dpkg` / `which rpm`

### Testing infrastructure
- `scripts/test-local-update.js`: serves Squirrel output from a local build as a fake GitHub release on port 9999
- `scripts/test-e2e-verify.js`: automated verification — fetches release, rewrites RELEASES, starts feed server, validates format, checks nupkg is downloadable
- `TMAX_UPDATE_TEST_URL` env var override for pointing version-checker at localhost

### Diagnostic logging
- All update paths log with `[update]` prefix for easy debugging in DevTools Console

## Backward Compatibility
- Handles both old format (single `RELEASES` + `tmax-X.Y.Z-full.nupkg`) and new format (`RELEASES-x64` + `tmax-X.Y.Z-x64-full.nupkg`)
- Falls back gracefully: Squirrel → GitHub API → manual download link

## Testing

Verified end-to-end against local build output:
```
1. Fetch release from test server          PASS
2. Find RELEASES + nupkg assets            PASS
3. Download RELEASES content               PASS
4. Rewrite nupkg URLs to absolute          PASS
5. Start local feed server                 PASS
6. Squirrel receives valid RELEASES        PASS
7. SHA1 hash (40 hex chars)                PASS
   URL is absolute                         PASS
   Size is numeric                         PASS
   nupkg downloadable (HTTP 200, 116 MB)   PASS
   Size matches Content-Length             PASS
```

Also verified against real v1.4.8 GitHub release data (RELEASES file + asset URLs).