### PR TITLE
feat: System (Auto) theme mode

### DIFF
--- a/src/main/config-store.ts
+++ b/src/main/config-store.ts
@@ -45,6 +45,8 @@ export interface TerminalDefaults {
 
 export type BackgroundMaterial = 'none' | 'auto' | 'mica' | 'acrylic' | 'tabbed';
 
+export type ThemeMode = 'manual' | 'system';
+
 export interface AppConfig {
   shells: ShellProfile[];
   defaultShellId: string;
@@ -56,6 +58,7 @@ export interface AppConfig {
   tabBarPosition?: 'top' | 'bottom' | 'left' | 'right';
   backgroundMaterial?: BackgroundMaterial;
   backgroundOpacity?: number; // 0.0–1.0, default 0.8
+  themeMode?: ThemeMode; // 'manual' | 'system', default 'manual'
 }
 
 function findPwsh(): string | null {
@@ -166,6 +169,23 @@ const defaultConfig: AppConfig = {
   claudeCodeCommand: 'claude',
   backgroundMaterial: 'none',
   backgroundOpacity: 0.8,
+  themeMode: 'manual',
+};
+
+export const DARK_THEME_PRESET: ThemeColors = {
+  background: '#1e1e2e', foreground: '#cdd6f4', cursor: '#f5e0dc', selectionBackground: '#585b70',
+  black: '#45475a', red: '#f38ba8', green: '#a6e3a1', yellow: '#f9e2af',
+  blue: '#89b4fa', magenta: '#f5c2e7', cyan: '#94e2d5', white: '#bac2de',
+  brightBlack: '#585b70', brightRed: '#f38ba8', brightGreen: '#a6e3a1', brightYellow: '#f9e2af',
+  brightBlue: '#89b4fa', brightMagenta: '#f5c2e7', brightCyan: '#94e2d5', brightWhite: '#a6adc8',
+};
+
+export const LIGHT_THEME_PRESET: ThemeColors = {
+  background: '#eff1f5', foreground: '#4c4f69', cursor: '#dc8a78', selectionBackground: '#acb0be',
+  black: '#5c5f77', red: '#d20f39', green: '#40a02b', yellow: '#df8e1d',
+  blue: '#1e66f5', magenta: '#ea76cb', cyan: '#179299', white: '#bcc0cc',
+  brightBlack: '#6c6f85', brightRed: '#d20f39', brightGreen: '#40a02b', brightYellow: '#df8e1d',
+  brightBlue: '#1e66f5', brightMagenta: '#ea76cb', brightCyan: '#179299', brightWhite: '#bcc0cc',
 };
 
 export class ConfigStore {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import Store from 'electron-store';
 import { PtyManager } from './pty-manager';
 import { ConfigStore } from './config-store';
-import type { BackgroundMaterial } from './config-store';
+import type { BackgroundMaterial, ThemeMode } from './config-store';
 import { IPC } from '../shared/ipc-channels';
 import { CopilotSessionMonitor } from './copilot-session-monitor';
 import { CopilotSessionWatcher } from './copilot-session-watcher';
@@ -360,6 +360,10 @@ function registerIpcHandlers(): void {
     return configStore!.getAll();
   });
 
+  ipcMain.handle(IPC.SHOULD_USE_DARK_COLORS, () => {
+    return nativeTheme.shouldUseDarkColors;
+  });
+
   ipcMain.handle(
     IPC.CONFIG_SET,
     (_event, key: string, value: unknown) => {
@@ -373,6 +377,25 @@ function registerIpcHandlers(): void {
             applyMaterialToWindow(win);
           }
         }
+      }
+
+      // Update window chrome when theme mode changes
+      if (key === 'themeMode') {
+        const mode = value as ThemeMode;
+        if (mode === 'system') {
+          nativeTheme.themeSource = 'system';
+        } else {
+          const theme = configStore!.get('theme');
+          const bg = theme?.background || '#1e1e2e';
+          nativeTheme.themeSource = isLightColor(bg) ? 'light' : 'dark';
+        }
+      }
+
+      // Update window chrome when theme colors change in manual mode
+      if (key === 'theme' && configStore!.get('themeMode') !== 'system') {
+        const theme = value as Record<string, string>;
+        const bg = theme?.background || '#1e1e2e';
+        nativeTheme.themeSource = isLightColor(bg) ? 'light' : 'dark';
       }
     }
   );
@@ -758,10 +781,38 @@ process.on('uncaughtException', (error) => {
   console.error('Uncaught exception in main process:', error);
 });
 
+/** Simple luminance check — returns true if the hex color is light */
+function isLightColor(hex: string): boolean {
+  const c = hex.replace('#', '');
+  const r = parseInt(c.substring(0, 2), 16);
+  const g = parseInt(c.substring(2, 4), 16);
+  const b = parseInt(c.substring(4, 6), 16);
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.5;
+}
+
 app.whenReady().then(() => {
   try {
-    // Force dark title bar/frame regardless of Windows system theme
-    nativeTheme.themeSource = 'dark';
+    // Set title bar / window chrome theme based on config
+    const themeMode = configStore?.get('themeMode') || 'manual';
+    if (themeMode === 'system') {
+      nativeTheme.themeSource = 'system';
+    } else {
+      // For manual mode, detect from current theme colors
+      const theme = configStore?.get('theme');
+      const bg = theme?.background || '#1e1e2e';
+      const isDark = !isLightColor(bg);
+      nativeTheme.themeSource = isDark ? 'dark' : 'light';
+    }
+
+    // Broadcast OS theme changes to all renderer windows
+    nativeTheme.on('updated', () => {
+      const allWindows = [mainWindow, ...detachedWindows.values()];
+      for (const win of allWindows) {
+        if (win && !win.isDestroyed()) {
+          win.webContents.send(IPC.NATIVE_THEME_UPDATED, nativeTheme.shouldUseDarkColors);
+        }
+      }
+    });
 
     // On macOS, a null menu creates default accelerators (Cmd+C/V/X) that
     // intercept events before the renderer. Use a minimal menu instead.

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -45,6 +45,9 @@ export interface TerminalAPI {
   // ── Transparency ──────────────────────────────────────────────────
   setBackgroundMaterial(material: string): Promise<void>;
   getPlatformSupportsMaterial(): Promise<boolean>;
+  // ── Theme ──────────────────────────────────────────────────────────
+  onNativeThemeUpdated(cb: (shouldUseDarkColors: boolean) => void): () => void;
+  shouldUseDarkColors(): Promise<boolean>;
   // ── Diff editor ──────────────────────────────────────────────────
   diffResolveGitRoot(cwd: string): Promise<string>;
   diffGetDiff(cwd: string, mode: DiffMode): Promise<DiffResult>;
@@ -315,6 +318,17 @@ const terminalAPI: TerminalAPI = {
 
   getPlatformSupportsMaterial(): Promise<boolean> {
     return ipcRenderer.invoke(IPC.GET_PLATFORM_SUPPORTS_MATERIAL);
+  },
+
+  // ── Theme ──────────────────────────────────────────────────────────
+  onNativeThemeUpdated(cb: (shouldUseDarkColors: boolean) => void) {
+    const listener = (_event: Electron.IpcRendererEvent, shouldUseDarkColors: boolean) => cb(shouldUseDarkColors);
+    ipcRenderer.on(IPC.NATIVE_THEME_UPDATED, listener);
+    return () => { ipcRenderer.removeListener(IPC.NATIVE_THEME_UPDATED, listener); };
+  },
+
+  shouldUseDarkColors() {
+    return ipcRenderer.invoke(IPC.SHOULD_USE_DARK_COLORS);
   },
 
   // ── Diff editor ──────────────────────────────────────────────────

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -113,6 +113,7 @@ const CommandPalette: React.FC = () => {
       { id: 'theme-solarized-light', label: 'Theme: Solarized Light', action: () => store().updateConfig({ theme: { background: '#fdf6e3', foreground: '#657b83', cursor: '#586e75', selectionBackground: '#eee8d5', black: '#073642', red: '#dc322f', green: '#859900', yellow: '#b58900', blue: '#268bd2', magenta: '#d33682', cyan: '#2aa198', white: '#eee8d5' } }) },
       { id: 'theme-github-light', label: 'Theme: GitHub Light', action: () => store().updateConfig({ theme: { background: '#ffffff', foreground: '#24292e', cursor: '#044289', selectionBackground: '#c8c8fa', black: '#24292e', red: '#d73a49', green: '#22863a', yellow: '#b08800', blue: '#0366d6', magenta: '#6f42c1', cyan: '#1b7c83', white: '#6a737d' } }) },
       { id: 'theme-catppuccin-latte', label: 'Theme: Catppuccin Latte', action: () => store().updateConfig({ theme: { background: '#eff1f5', foreground: '#4c4f69', cursor: '#dc8a78', selectionBackground: '#acb0be', black: '#5c5f77', red: '#d20f39', green: '#40a02b', yellow: '#df8e1d', blue: '#1e66f5', magenta: '#ea76cb', cyan: '#179299', white: '#bcc0cc' } }) },
+      { id: 'theme-system', label: 'Theme: System (Auto)', action: () => store().updateConfig({ themeMode: 'system' } as any) },
       // Shell-specific new terminals
       ...(useTerminalStore.getState().config?.shells ?? []).map((shell) => ({
         id: `newTerminal-${shell.id}`,

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -297,6 +297,19 @@ const ThemeSettings: React.FC = () => {
 
   return (
     <div className="settings-section">
+      <SettingRow label="Theme Mode" description="Manual: use a specific theme. System: follow OS dark/light appearance.">
+        <select className="settings-input"
+          value={config.themeMode || 'manual'}
+          onChange={(e) => update({ themeMode: e.target.value as any } as any)}>
+          <option value="manual">Manual</option>
+          <option value="system">System (Auto)</option>
+        </select>
+      </SettingRow>
+      {config.themeMode === 'system' && (
+        <div style={{ padding: '4px 12px 8px', opacity: 0.7, fontSize: '12px' }}>
+          Theme follows OS appearance. Pick a theme from the command palette to override.
+        </div>
+      )}
       <div className="theme-grid">
         {colors.map(({ key, label }) => (
           <div key={key} className="theme-color-row">

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -2278,9 +2278,19 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   },
 
   setSessionNameOverride: (sessionId: string, name: string) => {
-    set((s) => ({
-      sessionNameOverrides: { ...s.sessionNameOverrides, [sessionId]: name },
-    }));
+    set((s) => {
+      // Also sync the terminal pane/tab title for any terminal linked to this session
+      const updatedTerminals = new Map(s.terminals);
+      for (const [id, inst] of updatedTerminals) {
+        if (inst.aiSessionId === sessionId) {
+          updatedTerminals.set(id, { ...inst, title: name, customTitle: true, aiAutoTitle: false });
+        }
+      }
+      return {
+        sessionNameOverrides: { ...s.sessionNameOverrides, [sessionId]: name },
+        terminals: updatedTerminals,
+      };
+    });
     get().saveSession();
   },
 

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -16,6 +16,19 @@ import type { CopilotSessionSummary } from '../../shared/copilot-types';
 import type { DiffMode } from '../../shared/diff-types';
 import { getAllTerminals, getAllTerminalEntries, setWebglAddon, disposeTerminal } from '../terminal-registry';
 
+// ── Theme presets (Catppuccin Mocha / Latte) ─────────────────────────
+export const DARK_THEME_PRESET: Record<string, string> = {
+  background: '#1e1e2e', foreground: '#cdd6f4', cursor: '#f5e0dc', selectionBackground: '#585b70',
+  black: '#45475a', red: '#f38ba8', green: '#a6e3a1', yellow: '#f9e2af',
+  blue: '#89b4fa', magenta: '#f5c2e7', cyan: '#94e2d5', white: '#bac2de',
+};
+
+export const LIGHT_THEME_PRESET: Record<string, string> = {
+  background: '#eff1f5', foreground: '#4c4f69', cursor: '#dc8a78', selectionBackground: '#acb0be',
+  black: '#5c5f77', red: '#d20f39', green: '#40a02b', yellow: '#df8e1d',
+  blue: '#1e66f5', magenta: '#ea76cb', cyan: '#179299', white: '#bcc0cc',
+};
+
 // Session IDs must be alphanumeric/dash/dot/underscore only (prevent shell injection)
 const SAFE_SESSION_ID = /^[a-zA-Z0-9._-]+$/;
 
@@ -731,6 +744,22 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       document.documentElement.style.setProperty('--terminal-opacity', String((config as any).terminalOpacity));
     }
     set(updates);
+
+    // Subscribe to OS theme changes for system theme mode
+    if (window.terminalAPI.onNativeThemeUpdated) {
+      window.terminalAPI.onNativeThemeUpdated((shouldUseDarkColors: boolean) => {
+        const { config: currentConfig } = get();
+        if (currentConfig?.themeMode !== 'system') return;
+        const preset = shouldUseDarkColors ? DARK_THEME_PRESET : LIGHT_THEME_PRESET;
+        const newTheme = { ...currentConfig.theme, ...preset };
+        const matActive = currentConfig?.backgroundMaterial && currentConfig.backgroundMaterial !== 'none';
+        const op = matActive ? (currentConfig?.backgroundOpacity ?? 0.8) : undefined;
+        applyThemeToChromeVars(newTheme, op);
+        set({ config: { ...currentConfig, theme: newTheme } });
+        // Persist the theme colours (not themeMode — that stays 'system')
+        window.terminalAPI.setConfig('theme', newTheme);
+      });
+    }
   },
 
   createTerminal: async (shellProfileId?: string) => {
@@ -1462,6 +1491,19 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   updateConfig: async (update: Partial<AppConfig>) => {
     const { config } = get();
     if (!config) return;
+
+    // When user explicitly picks a theme (but NOT when setting themeMode), revert to manual
+    if (update.theme && !update.themeMode) {
+      update = { ...update, themeMode: 'manual' };
+    }
+
+    // When switching to system mode, apply matching preset immediately
+    if (update.themeMode === 'system' && !update.theme) {
+      const shouldUseDark = await window.terminalAPI.shouldUseDarkColors?.() ?? true;
+      const preset = shouldUseDark ? DARK_THEME_PRESET : LIGHT_THEME_PRESET;
+      update = { ...update, theme: { ...config.theme, ...preset } };
+    }
+
     const newConfig = { ...config, ...update };
     for (const [key, value] of Object.entries(update)) {
       await window.terminalAPI.setConfig(key, value);

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -2278,19 +2278,9 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   },
 
   setSessionNameOverride: (sessionId: string, name: string) => {
-    set((s) => {
-      // Also sync the terminal pane/tab title for any terminal linked to this session
-      const updatedTerminals = new Map(s.terminals);
-      for (const [id, inst] of updatedTerminals) {
-        if (inst.aiSessionId === sessionId) {
-          updatedTerminals.set(id, { ...inst, title: name, customTitle: true, aiAutoTitle: false });
-        }
-      }
-      return {
-        sessionNameOverrides: { ...s.sessionNameOverrides, [sessionId]: name },
-        terminals: updatedTerminals,
-      };
-    });
+    set((s) => ({
+      sessionNameOverrides: { ...s.sessionNameOverrides, [sessionId]: name },
+    }));
     get().saveSession();
   },
 

--- a/src/renderer/state/types.ts
+++ b/src/renderer/state/types.ts
@@ -103,6 +103,8 @@ export interface TerminalConfig {
 
 export type BackgroundMaterial = 'none' | 'auto' | 'mica' | 'acrylic' | 'tabbed';
 
+export type ThemeMode = 'manual' | 'system';
+
 export interface AppConfig {
   shells: ShellProfile[];
   defaultShellId: string;
@@ -114,6 +116,7 @@ export interface AppConfig {
   tabBarPosition?: 'top' | 'bottom' | 'left' | 'right';
   backgroundMaterial?: BackgroundMaterial;
   backgroundOpacity?: number; // 0.0–1.0, default 0.8
+  themeMode?: ThemeMode; // 'manual' | 'system', default 'manual'
 }
 
 // ── Drag & drop ──────────────────────────────────────────────────────

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -46,6 +46,9 @@ export const IPC = {
   // ── Transparency ────────────────────────────────────────────────────
   SET_BACKGROUND_MATERIAL: 'transparency:setMaterial',
   GET_PLATFORM_SUPPORTS_MATERIAL: 'transparency:platformSupports',
+  // ── Theme ─────────────────────────────────────────────────────────
+  NATIVE_THEME_UPDATED: 'theme:nativeUpdated',
+  SHOULD_USE_DARK_COLORS: 'theme:shouldUseDarkColors',
   // ── Diff editor ────────────────────────────────────────────────────
   DIFF_RESOLVE_GIT_ROOT: 'diff:resolveGitRoot',
   DIFF_GET_CODE_CHANGES: 'diff:getCodeChanges',


### PR DESCRIPTION
## What Changed

- **New theme option: System (Auto)** — the app now follows your OS dark/light appearance automatically
- When active, switches between Catppuccin Mocha (dark) and Catppuccin Latte (light) based on your OS setting
- **Real-time switching** — changes instantly when you toggle dark/light mode in System Settings
- Window title bar chrome also follows the OS theme
- Picking any specific theme from the command palette (e.g. Dracula, Nord) automatically disables system mode
- Added Theme Mode dropdown in Settings > Theme tab

## How

- Uses Electron's `nativeTheme` API (`shouldUseDarkColors`, `nativeTheme.on('updated')`) — same approach as VS Code, Slack, etc.
- Works on **macOS, Windows 10/11, and Linux**
- Added `themeMode: 'manual' | 'system'` to config persistence
- Main process broadcasts OS theme changes to renderer via IPC
- Renderer subscribes and applies matching theme preset when in system mode
- `nativeTheme.themeSource = 'system'` ensures window chrome follows OS too