### PR TITLE
feat: Pipeline Tracker — live ADO pipeline monitoring on pane footer

### DIFF
--- a/scripts/tmax-pipeline-monitor.js
+++ b/scripts/tmax-pipeline-monitor.js
@@ -5,17 +5,17 @@
  * watches to render a progress widget on the originating terminal pane.
  *
  * Usage:
- *   tmax-pipeline-monitor --build-id 1234 --org https://dev.azure.com/myorg \
- *     --project MyProject [--pat $ADO_PAT]
+ *   TMAX_PANE_ID=<uuid> ADO_PAT=<token> tmax-pipeline-monitor \
+ *     --build-id 1234 --org https://dev.azure.com/myorg --project MyProject
  *
+ * PAT must be provided via ADO_PAT or AZURE_DEVOPS_PAT env var (never CLI args).
  * Reads TMAX_PANE_ID from environment to know which file to write.
- * Writes to ~/.tmax/pipeline/{TMAX_PANE_ID}.json
+ * Writes to ~/.tmax/pipeline/{TMAX_PANE_ID}-{buildId}.json
  *
  * The AI auto-launches this after triggering a pipeline via its MCP tools.
  */
 
 const https = require('node:https');
-const http = require('node:http');
 const fs = require('node:fs');
 const path = require('node:path');
 const { URL } = require('node:url');
@@ -30,12 +30,12 @@ function getArg(name) {
 const buildId = getArg('build-id');
 const org = getArg('org');       // e.g. https://dev.azure.com/myorg
 const project = getArg('project');
-const pat = getArg('pat') || process.env.ADO_PAT || process.env.AZURE_DEVOPS_PAT;
+const pat = process.env.ADO_PAT || process.env.AZURE_DEVOPS_PAT;
 const paneId = process.env.TMAX_PANE_ID;
 const pollInterval = parseInt(getArg('interval') || '15', 10) * 1000;
 
 if (!buildId || !org || !project) {
-  console.error('Usage: tmax-pipeline-monitor --build-id ID --org ORG_URL --project PROJECT [--pat PAT]');
+  console.error('Usage: ADO_PAT=<token> tmax-pipeline-monitor --build-id ID --org ORG_URL --project PROJECT');
   process.exit(1);
 }
 
@@ -44,8 +44,27 @@ if (!paneId) {
   process.exit(1);
 }
 
+// ── Security: validate org URL ─────────────────────────────────────────
+const ALLOWED_HOSTS = ['dev.azure.com', 'visualstudio.com'];
+try {
+  const orgUrl = new URL(org);
+  if (orgUrl.protocol !== 'https:') {
+    console.error('Error: org URL must use HTTPS');
+    process.exit(1);
+  }
+  const host = orgUrl.hostname.toLowerCase();
+  if (!ALLOWED_HOSTS.some(h => host === h || host.endsWith('.' + h))) {
+    console.error(`Error: org hostname "${host}" not in allowed list (${ALLOWED_HOSTS.join(', ')})`);
+    process.exit(1);
+  }
+} catch (e) {
+  console.error(`Error: invalid org URL: ${org}`);
+  process.exit(1);
+}
+
 const statusDir = path.join(require('node:os').homedir(), '.tmax', 'pipeline');
-const statusFile = path.join(statusDir, `${paneId}.json`);
+const statusFile = path.join(statusDir, `${paneId}-${buildId}.json`);
+const dismissFile = path.join(statusDir, `${paneId}.dismissed`);
 
 // Ensure directory exists
 fs.mkdirSync(statusDir, { recursive: true });
@@ -71,8 +90,7 @@ function adoFetch(apiPath) {
       },
     };
 
-    const client = url.protocol === 'https:' ? https : http;
-    const req = client.request(options, (res) => {
+    const req = https.request(options, (res) => {
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
@@ -88,14 +106,28 @@ function adoFetch(apiPath) {
   });
 }
 
+// ── Dismiss check ──────────────────────────────────────────────────────
+function isDismissed() {
+  try {
+    return fs.existsSync(dismissFile);
+  } catch {
+    return false;
+  }
+}
+
 // ── Polling loop ───────────────────────────────────────────────────────
 const TERMINAL_RESULTS = new Set(['succeeded', 'failed', 'canceled']);
 
 async function poll() {
+  // Check if user dismissed tracking
+  if (isDismissed()) {
+    console.log('User dismissed pipeline tracking, exiting');
+    cleanup();
+    process.exit(0);
+  }
+
   try {
-    // Get build info
     const build = await adoFetch(`/build/builds/${buildId}`);
-    // Get timeline (stages)
     const timeline = await adoFetch(`/build/builds/${buildId}/timeline`);
 
     const stages = (timeline.records || [])
@@ -143,7 +175,7 @@ async function poll() {
       console.log(`Pipeline ${buildId} finished: ${build.result}`);
       // Keep file for a bit so tmax can show final state, then clean up
       setTimeout(() => {
-        try { fs.unlinkSync(statusFile); } catch {}
+        cleanupIfOurs();
         process.exit(0);
       }, 30000);
       return false; // Stop polling
@@ -176,6 +208,23 @@ function mapResult(result) {
   return null;
 }
 
+/** Only delete the status file if it still belongs to this buildId */
+function cleanupIfOurs() {
+  try {
+    const raw = fs.readFileSync(statusFile, 'utf-8');
+    const data = JSON.parse(raw);
+    if (data.buildId === parseInt(buildId, 10)) {
+      fs.unlinkSync(statusFile);
+    }
+  } catch {
+    // File already gone or different run
+  }
+}
+
+function cleanup() {
+  try { fs.unlinkSync(statusFile); } catch {}
+}
+
 // ── Main ───────────────────────────────────────────────────────────────
 async function main() {
   console.log(`Monitoring pipeline build ${buildId} for pane ${paneId}`);
@@ -192,11 +241,11 @@ async function main() {
 
 // Clean up status file on exit
 process.on('SIGINT', () => {
-  try { fs.unlinkSync(statusFile); } catch {}
+  cleanup();
   process.exit(0);
 });
 process.on('SIGTERM', () => {
-  try { fs.unlinkSync(statusFile); } catch {}
+  cleanup();
   process.exit(0);
 });
 

--- a/scripts/tmax-pipeline-monitor.js
+++ b/scripts/tmax-pipeline-monitor.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * tmax-pipeline-monitor — Background script that polls an Azure DevOps
+ * pipeline run and writes stage-level status to a JSON file that tmax
+ * watches to render a progress widget on the originating terminal pane.
+ *
+ * Usage:
+ *   tmax-pipeline-monitor --build-id 1234 --org https://dev.azure.com/myorg \
+ *     --project MyProject [--pat $ADO_PAT]
+ *
+ * Reads TMAX_PANE_ID from environment to know which file to write.
+ * Writes to ~/.tmax/pipeline/{TMAX_PANE_ID}.json
+ *
+ * The AI auto-launches this after triggering a pipeline via its MCP tools.
+ */
+
+const https = require('node:https');
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+const { URL } = require('node:url');
+
+// ── Parse args ─────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : null;
+}
+
+const buildId = getArg('build-id');
+const org = getArg('org');       // e.g. https://dev.azure.com/myorg
+const project = getArg('project');
+const pat = getArg('pat') || process.env.ADO_PAT || process.env.AZURE_DEVOPS_PAT;
+const paneId = process.env.TMAX_PANE_ID;
+const pollInterval = parseInt(getArg('interval') || '15', 10) * 1000;
+
+if (!buildId || !org || !project) {
+  console.error('Usage: tmax-pipeline-monitor --build-id ID --org ORG_URL --project PROJECT [--pat PAT]');
+  process.exit(1);
+}
+
+if (!paneId) {
+  console.error('Error: TMAX_PANE_ID environment variable not set. Run this from a tmax terminal pane.');
+  process.exit(1);
+}
+
+const statusDir = path.join(require('node:os').homedir(), '.tmax', 'pipeline');
+const statusFile = path.join(statusDir, `${paneId}.json`);
+
+// Ensure directory exists
+fs.mkdirSync(statusDir, { recursive: true });
+
+// ── ADO API client ─────────────────────────────────────────────────────
+const authHeader = pat
+  ? `Basic ${Buffer.from(`:${pat}`).toString('base64')}`
+  : undefined;
+
+function adoFetch(apiPath) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${org.replace(/\/$/, '')}/${encodeURIComponent(project)}/_apis${apiPath}`);
+    url.searchParams.set('api-version', '7.1');
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        ...(authHeader ? { 'Authorization': authHeader } : {}),
+      },
+    };
+
+    const client = url.protocol === 'https:' ? https : http;
+    const req = client.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          try { resolve(JSON.parse(data)); } catch (e) { reject(new Error(`Parse error: ${e.message}`)); }
+        } else {
+          reject(new Error(`ADO API ${res.statusCode}: ${data.slice(0, 200)}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// ── Polling loop ───────────────────────────────────────────────────────
+const TERMINAL_RESULTS = new Set(['succeeded', 'failed', 'canceled']);
+
+async function poll() {
+  try {
+    // Get build info
+    const build = await adoFetch(`/build/builds/${buildId}`);
+    // Get timeline (stages)
+    const timeline = await adoFetch(`/build/builds/${buildId}/timeline`);
+
+    const stages = (timeline.records || [])
+      .filter(r => r.type === 'Stage' && r.name !== '__default')
+      .sort((a, b) => (a.order || 0) - (b.order || 0))
+      .map(r => {
+        const stage = {
+          name: r.name,
+          state: mapState(r.state),
+          result: mapResult(r.result),
+        };
+
+        if (r.startTime) {
+          const start = new Date(r.startTime).getTime();
+          if (r.finishTime) {
+            stage.duration = Math.round((new Date(r.finishTime).getTime() - start) / 1000);
+          } else {
+            stage.elapsed = Math.round((Date.now() - start) / 1000);
+          }
+        }
+
+        return stage;
+      });
+
+    const startTime = build.startTime || build.queueTime || new Date().toISOString();
+    const status = {
+      buildId: parseInt(buildId, 10),
+      pipelineName: build.definition?.name || `Build #${buildId}`,
+      sourceBranch: (build.sourceBranch || '').replace('refs/heads/', ''),
+      status: mapState(build.status),
+      result: mapResult(build.result),
+      stages,
+      startTime,
+      estimatedRemaining: null,
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Write atomically (write to temp, rename)
+    const tmpFile = statusFile + '.tmp';
+    fs.writeFileSync(tmpFile, JSON.stringify(status, null, 2));
+    fs.renameSync(tmpFile, statusFile);
+
+    // Check if we should stop
+    if (TERMINAL_RESULTS.has(build.result)) {
+      console.log(`Pipeline ${buildId} finished: ${build.result}`);
+      // Keep file for a bit so tmax can show final state, then clean up
+      setTimeout(() => {
+        try { fs.unlinkSync(statusFile); } catch {}
+        process.exit(0);
+      }, 30000);
+      return false; // Stop polling
+    }
+
+    return true; // Continue polling
+  } catch (err) {
+    console.error(`Poll error: ${err.message}`);
+    return true; // Keep trying
+  }
+}
+
+function mapState(state) {
+  if (!state) return 'pending';
+  const s = state.toLowerCase();
+  if (s === 'completed') return 'completed';
+  if (s === 'inprogress') return 'inProgress';
+  if (s === 'cancelling') return 'cancelling';
+  if (s === 'notstarted' || s === 'pending') return 'pending';
+  return 'pending';
+}
+
+function mapResult(result) {
+  if (!result) return null;
+  const r = result.toLowerCase();
+  if (r === 'succeeded') return 'succeeded';
+  if (r === 'failed') return 'failed';
+  if (r === 'canceled' || r === 'cancelled') return 'canceled';
+  if (r === 'skipped') return 'skipped';
+  return null;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+async function main() {
+  console.log(`Monitoring pipeline build ${buildId} for pane ${paneId}`);
+  console.log(`Writing status to ${statusFile}`);
+
+  let shouldContinue = true;
+  while (shouldContinue) {
+    shouldContinue = await poll();
+    if (shouldContinue) {
+      await new Promise(r => setTimeout(r, pollInterval));
+    }
+  }
+}
+
+// Clean up status file on exit
+process.on('SIGINT', () => {
+  try { fs.unlinkSync(statusFile); } catch {}
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  try { fs.unlinkSync(statusFile); } catch {}
+  process.exit(0);
+});
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import { ClaudeCodeSessionMonitor } from './claude-code-session-monitor';
 import { ClaudeCodeSessionWatcher } from './claude-code-session-watcher';
 import { WslSessionManager } from './wsl-session-manager';
 import { VersionChecker } from './version-checker';
+import { PipelineWatcher } from './pipeline-watcher';
 import { initDiagLogger, getDiagLogPath, diagLog } from './diag-logger';
 import { GitDiffService, resolveGitRoot } from './git-diff-service';
 import type { DiffMode } from '../shared/diff-types';
@@ -131,6 +132,7 @@ let claudeCodeMonitor: ClaudeCodeSessionMonitor | null = null;
 let claudeCodeWatcher: ClaudeCodeSessionWatcher | null = null;
 let wslSessionManager: WslSessionManager | null = null;
 let versionChecker: VersionChecker | null = null;
+let pipelineWatcher: PipelineWatcher | null = null;
 let clipboardTempDir: string | null = null;
 const sessionStore = new Store({ name: 'tmax-session' });
 const detachedWindows = new Map<string, BrowserWindow>();
@@ -808,6 +810,9 @@ app.whenReady().then(() => {
     versionChecker = new VersionChecker(mainWindow!);
     versionChecker.start();
     console.log('Version checker started');
+    pipelineWatcher = new PipelineWatcher(() => mainWindow);
+    pipelineWatcher.start();
+    console.log('Pipeline watcher started');
     // Start WSL discovery after window is visible — WSL distro detection
     // uses synchronous subprocess calls that can block for several seconds
     setupWslSessionManager().then(() => {

--- a/src/main/pipeline-watcher.ts
+++ b/src/main/pipeline-watcher.ts
@@ -11,10 +11,14 @@ import { IPC } from '../shared/ipc-channels';
 import type { PipelineStatus } from '../shared/pipeline-types';
 import { diagLog } from './diag-logger';
 
+// Strict pane ID validation: UUIDs only (no path traversal)
+const VALID_PANE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export class PipelineWatcher {
   private dir: string;
   private watcher: fs.FSWatcher | null = null;
   private lastStatus = new Map<string, string>();
+  private rescanTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private getWindow: () => BrowserWindow | null) {
     this.dir = path.join(app.getPath('home'), '.tmax', 'pipeline');
@@ -38,6 +42,9 @@ export class PipelineWatcher {
 
     // Read any existing files on startup
     this.scanExisting();
+
+    // Periodic rescan as fallback — fs.watch can miss events
+    this.rescanTimer = setInterval(() => this.scanExisting(), 30_000);
   }
 
   stop(): void {
@@ -45,18 +52,33 @@ export class PipelineWatcher {
       this.watcher.close();
       this.watcher = null;
     }
+    if (this.rescanTimer) {
+      clearInterval(this.rescanTimer);
+      this.rescanTimer = null;
+    }
   }
 
   private registerIpc(): void {
     ipcMain.on(IPC.PIPELINE_DISMISS, (_event, paneId: string) => {
-      // Remove the status file so the monitor knows to stop
-      const filePath = path.join(this.dir, `${paneId}.json`);
+      if (!VALID_PANE_ID.test(paneId)) return;
+
+      // Remove all status files for this pane
       try {
-        fs.unlinkSync(filePath);
-      } catch {
-        // Already gone
+        const files = fs.readdirSync(this.dir).filter(f => f.startsWith(paneId) && f.endsWith('.json'));
+        for (const f of files) {
+          try { fs.unlinkSync(path.join(this.dir, f)); } catch {}
+        }
+      } catch {}
+
+      // Write a dismiss marker so the monitor script knows to stop
+      try {
+        fs.writeFileSync(path.join(this.dir, `${paneId}.dismissed`), '');
+      } catch {}
+
+      // Clear cached status for all files matching this pane
+      for (const key of this.lastStatus.keys()) {
+        if (key.startsWith(paneId)) this.lastStatus.delete(key);
       }
-      this.lastStatus.delete(paneId);
       this.sendToRenderer(paneId, null);
     });
   }
@@ -64,8 +86,19 @@ export class PipelineWatcher {
   private scanExisting(): void {
     try {
       const files = fs.readdirSync(this.dir).filter(f => f.endsWith('.json'));
+      const seenPanes = new Set<string>();
       for (const file of files) {
         this.handleFileChange(file);
+        const paneId = file.split('-').slice(0, 5).join('-'); // extract UUID
+        seenPanes.add(paneId);
+      }
+      // If a pane had status but no file anymore, send null
+      for (const key of this.lastStatus.keys()) {
+        const paneId = key.split('-').slice(0, 5).join('-');
+        if (!seenPanes.has(paneId)) {
+          this.lastStatus.delete(key);
+          this.sendToRenderer(paneId, null);
+        }
       }
     } catch {
       // Dir doesn't exist or read error
@@ -73,21 +106,31 @@ export class PipelineWatcher {
   }
 
   private handleFileChange(filename: string): void {
-    const paneId = filename.replace('.json', '');
+    // Filename format: {paneId}-{buildId}.json or legacy {paneId}.json
+    const basename = filename.replace('.json', '');
+    const parts = basename.split('-');
+    // UUID is 5 groups separated by hyphens
+    const paneId = parts.slice(0, 5).join('-');
+    if (!VALID_PANE_ID.test(paneId)) return;
+
     const filePath = path.join(this.dir, filename);
+
+    // Verify resolved path stays inside pipeline dir (defense in depth)
+    const resolved = path.resolve(filePath);
+    if (!resolved.startsWith(path.resolve(this.dir) + path.sep)) return;
 
     try {
       if (!fs.existsSync(filePath)) {
         // File was deleted — pipeline tracking ended
-        this.lastStatus.delete(paneId);
+        this.lastStatus.delete(basename);
         this.sendToRenderer(paneId, null);
         return;
       }
 
       const raw = fs.readFileSync(filePath, 'utf-8');
       // Debounce: skip if content hasn't changed
-      if (this.lastStatus.get(paneId) === raw) return;
-      this.lastStatus.set(paneId, raw);
+      if (this.lastStatus.get(basename) === raw) return;
+      this.lastStatus.set(basename, raw);
 
       const status: PipelineStatus = JSON.parse(raw);
       this.sendToRenderer(paneId, status);
@@ -109,7 +152,7 @@ export class PipelineWatcher {
       const files = fs.readdirSync(this.dir);
       const cutoff = Date.now() - 24 * 60 * 60 * 1000;
       for (const file of files) {
-        if (!file.endsWith('.json')) continue;
+        if (!file.endsWith('.json') && !file.endsWith('.dismissed')) continue;
         const filePath = path.join(this.dir, file);
         const stat = fs.statSync(filePath);
         if (stat.mtimeMs < cutoff) {

--- a/src/main/pipeline-watcher.ts
+++ b/src/main/pipeline-watcher.ts
@@ -1,0 +1,124 @@
+/**
+ * PipelineWatcher — watches ~/.tmax/pipeline/ for status JSON files written
+ * by the tmax-pipeline-monitor background script. Sends IPC updates to the
+ * renderer so the PipelineFooter widget can display live progress.
+ */
+
+import { app, BrowserWindow, ipcMain } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { IPC } from '../shared/ipc-channels';
+import type { PipelineStatus } from '../shared/pipeline-types';
+import { diagLog } from './diag-logger';
+
+export class PipelineWatcher {
+  private dir: string;
+  private watcher: fs.FSWatcher | null = null;
+  private lastStatus = new Map<string, string>();
+
+  constructor(private getWindow: () => BrowserWindow | null) {
+    this.dir = path.join(app.getPath('home'), '.tmax', 'pipeline');
+  }
+
+  /** Ensure the pipeline status directory exists and start watching */
+  start(): void {
+    fs.mkdirSync(this.dir, { recursive: true });
+    this.cleanStaleFiles();
+    this.registerIpc();
+
+    try {
+      this.watcher = fs.watch(this.dir, { persistent: false }, (eventType, filename) => {
+        if (!filename || !filename.endsWith('.json')) return;
+        this.handleFileChange(filename);
+      });
+      diagLog('pipeline:watcher-started', { dir: this.dir });
+    } catch (err) {
+      diagLog('pipeline:watcher-error', { error: String(err) });
+    }
+
+    // Read any existing files on startup
+    this.scanExisting();
+  }
+
+  stop(): void {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+  }
+
+  private registerIpc(): void {
+    ipcMain.on(IPC.PIPELINE_DISMISS, (_event, paneId: string) => {
+      // Remove the status file so the monitor knows to stop
+      const filePath = path.join(this.dir, `${paneId}.json`);
+      try {
+        fs.unlinkSync(filePath);
+      } catch {
+        // Already gone
+      }
+      this.lastStatus.delete(paneId);
+      this.sendToRenderer(paneId, null);
+    });
+  }
+
+  private scanExisting(): void {
+    try {
+      const files = fs.readdirSync(this.dir).filter(f => f.endsWith('.json'));
+      for (const file of files) {
+        this.handleFileChange(file);
+      }
+    } catch {
+      // Dir doesn't exist or read error
+    }
+  }
+
+  private handleFileChange(filename: string): void {
+    const paneId = filename.replace('.json', '');
+    const filePath = path.join(this.dir, filename);
+
+    try {
+      if (!fs.existsSync(filePath)) {
+        // File was deleted — pipeline tracking ended
+        this.lastStatus.delete(paneId);
+        this.sendToRenderer(paneId, null);
+        return;
+      }
+
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      // Debounce: skip if content hasn't changed
+      if (this.lastStatus.get(paneId) === raw) return;
+      this.lastStatus.set(paneId, raw);
+
+      const status: PipelineStatus = JSON.parse(raw);
+      this.sendToRenderer(paneId, status);
+    } catch {
+      // Partial write or invalid JSON — wait for next event
+    }
+  }
+
+  private sendToRenderer(paneId: string, status: PipelineStatus | null): void {
+    const win = this.getWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send(IPC.PIPELINE_STATUS_UPDATE, paneId, status);
+    }
+  }
+
+  /** Remove status files older than 24 hours */
+  private cleanStaleFiles(): void {
+    try {
+      const files = fs.readdirSync(this.dir);
+      const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        const filePath = path.join(this.dir, file);
+        const stat = fs.statSync(filePath);
+        if (stat.mtimeMs < cutoff) {
+          fs.unlinkSync(filePath);
+          diagLog('pipeline:cleaned-stale', { file });
+        }
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -101,7 +101,7 @@ export class PtyManager {
 
     const baseEnv = sanitizeEnv(opts.env ?? (process.env as Record<string, string>));
     const shellName = opts.shellPath.toLowerCase();
-    const shellEnv: Record<string, string> = { TERM_PROGRAM: 'tmax', COLORTERM: 'truecolor' };
+    const shellEnv: Record<string, string> = { TERM_PROGRAM: 'tmax', COLORTERM: 'truecolor', TMAX_PANE_ID: opts.id };
 
     // Set PROMPT_COMMAND via env var for native bash/zsh (not WSL — shell init takes longer)
     if (!shellName.includes('wsl') && (shellName.includes('bash') || shellName.includes('zsh'))) {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -52,6 +52,9 @@ export interface TerminalAPI {
   // ── File explorer ────────────────────────────────────────────────
   fileList(dirPath: string, wslDistro?: string): Promise<{ name: string; isDirectory: boolean; path: string }[]>;
   fileRead(filePath: string, wslDistro?: string): Promise<string | null>;
+  // ── Pipeline tracker ──────────────────────────────────────────
+  onPipelineStatusUpdate(cb: (paneId: string, status: unknown) => void): () => void;
+  dismissPipeline(paneId: string): void;
 }
 
 const terminalAPI: TerminalAPI = {
@@ -337,6 +340,21 @@ const terminalAPI: TerminalAPI = {
 
   fileRead(filePath: string, wslDistro?: string) {
     return ipcRenderer.invoke(IPC.FILE_READ, filePath, wslDistro);
+  },
+
+  // ── Pipeline tracker ──────────────────────────────────────────
+  onPipelineStatusUpdate(cb: (paneId: string, status: unknown) => void): () => void {
+    const listener = (_event: Electron.IpcRendererEvent, paneId: string, status: unknown) => {
+      cb(paneId, status);
+    };
+    ipcRenderer.on(IPC.PIPELINE_STATUS_UPDATE, listener);
+    return () => {
+      ipcRenderer.removeListener(IPC.PIPELINE_STATUS_UPDATE, listener);
+    };
+  },
+
+  dismissPipeline(paneId: string) {
+    ipcRenderer.send(IPC.PIPELINE_DISMISS, paneId);
   },
 
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import {
   pointerWithin,
 } from '@dnd-kit/core';
 import { useTerminalStore } from './state/terminal-store';
+import { initPipelineIpc } from './state/pipeline-store';
 import type { CopilotSessionSummary } from '../shared/copilot-types';
 import { useKeybindings } from './hooks/useKeybindings';
 import { useDragTerminal } from './hooks/useDragTerminal';
@@ -108,6 +109,9 @@ const App: React.FC = () => {
     });
 
     // Periodic stale session check (every 6 hours)
+    // Pipeline tracker IPC subscription
+    const unsubPipeline = initPipelineIpc();
+
     const staleCheckInterval = setInterval(() => {
       useTerminalStore.getState().checkStaleActiveSessions();
     }, 6 * 60 * 60 * 1000);
@@ -120,6 +124,7 @@ const App: React.FC = () => {
       clearInterval(heartbeatInterval);
       clearInterval(staleCheckInterval);
       unsubDetached?.();
+      unsubPipeline?.();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/renderer/components/PipelineFooter.tsx
+++ b/src/renderer/components/PipelineFooter.tsx
@@ -1,0 +1,150 @@
+/**
+ * PipelineFooter — renders at the bottom of a terminal pane when a pipeline
+ * run is being tracked for that pane. Shows stage progress, status icons,
+ * a progress bar, and estimated time remaining.
+ */
+
+import React, { useState } from 'react';
+import { usePipelineStore } from '../state/pipeline-store';
+import type { PipelineStatus, PipelineStage } from '../../shared/pipeline-types';
+
+interface Props {
+  paneId: string;
+}
+
+function stageIcon(stage: PipelineStage): string {
+  if (stage.state === 'completed') {
+    if (stage.result === 'succeeded') return '✓';
+    if (stage.result === 'failed') return '✗';
+    if (stage.result === 'canceled') return '⊘';
+    if (stage.result === 'skipped') return '⊘';
+    return '✓';
+  }
+  if (stage.state === 'inProgress') return '●';
+  if (stage.state === 'cancelling') return '⊘';
+  return '○';
+}
+
+function stageColor(stage: PipelineStage): string {
+  if (stage.state === 'completed') {
+    if (stage.result === 'succeeded') return '#a6e3a1';
+    if (stage.result === 'failed') return '#f38ba8';
+    if (stage.result === 'canceled') return '#a6adc8';
+    return '#a6e3a1';
+  }
+  if (stage.state === 'inProgress') return '#89b4fa';
+  return '#585b70';
+}
+
+function formatDuration(seconds: number | undefined | null): string {
+  if (seconds == null || seconds < 0) return '—';
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+function overallProgress(status: PipelineStatus): number {
+  if (!status.stages.length) return 0;
+  const completed = status.stages.filter(s => s.state === 'completed').length;
+  const inProgress = status.stages.filter(s => s.state === 'inProgress').length;
+  return ((completed + inProgress * 0.5) / status.stages.length) * 100;
+}
+
+function statusEmoji(status: PipelineStatus): string {
+  if (status.result === 'succeeded') return '✅';
+  if (status.result === 'failed') return '❌';
+  if (status.result === 'canceled') return '⊘';
+  if (status.status === 'inProgress') return '🔄';
+  return '⏳';
+}
+
+function estimateRemaining(status: PipelineStatus): string | null {
+  let totalRemaining = 0;
+  let hasEstimate = false;
+  for (const stage of status.stages) {
+    if (stage.state === 'completed') continue;
+    if (stage.estimated) {
+      hasEstimate = true;
+      const elapsed = stage.elapsed || 0;
+      totalRemaining += Math.max(0, stage.estimated - elapsed);
+    }
+  }
+  if (!hasEstimate) return null;
+  if (totalRemaining < 60) return `~${totalRemaining}s left`;
+  return `~${Math.ceil(totalRemaining / 60)} min left`;
+}
+
+export const PipelineFooter: React.FC<Props> = ({ paneId }) => {
+  const status = usePipelineStore((s) => s.statuses[paneId]);
+  const isDismissed = usePipelineStore((s) => s.dismissed.has(paneId));
+  const dismiss = usePipelineStore((s) => s.dismissPipeline);
+  const [expanded, setExpanded] = useState(true);
+
+  if (!status || isDismissed) return null;
+
+  const progress = overallProgress(status);
+  const remaining = estimateRemaining(status);
+  const isTerminal = status.result != null;
+
+  return (
+    <div className="pipeline-footer" onMouseDown={(e) => e.stopPropagation()}>
+      {/* Header bar — always visible */}
+      <div className="pipeline-footer-header" onClick={() => setExpanded(!expanded)}>
+        <span className="pipeline-footer-status">{statusEmoji(status)}</span>
+        <span className="pipeline-footer-name">{status.pipelineName}</span>
+        {status.sourceBranch && (
+          <span className="pipeline-footer-branch">{status.sourceBranch}</span>
+        )}
+        {/* Progress bar */}
+        <div className="pipeline-footer-progress-bar">
+          <div
+            className={`pipeline-footer-progress-fill ${isTerminal ? (status.result === 'succeeded' ? 'succeeded' : 'failed') : ''}`}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        {remaining && <span className="pipeline-footer-eta">{remaining}</span>}
+        <button
+          className="pipeline-footer-toggle"
+          title={expanded ? 'Collapse' : 'Expand'}
+        >
+          {expanded ? '▾' : '▸'}
+        </button>
+        <button
+          className="pipeline-footer-dismiss"
+          title="Dismiss"
+          onClick={(e) => {
+            e.stopPropagation();
+            dismiss(paneId);
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Stage details — shown when expanded */}
+      {expanded && (
+        <div className="pipeline-footer-stages">
+          {status.stages.map((stage) => (
+            <div key={stage.name} className="pipeline-footer-stage">
+              <span className="pipeline-stage-icon" style={{ color: stageColor(stage) }}>
+                {stageIcon(stage)}
+              </span>
+              <span className="pipeline-stage-name">{stage.name}</span>
+              <span className="pipeline-stage-time">
+                {stage.state === 'completed'
+                  ? formatDuration(stage.duration)
+                  : stage.state === 'inProgress'
+                    ? `${formatDuration(stage.elapsed)}/${formatDuration(stage.estimated)}`
+                    : stage.estimated
+                      ? `~${formatDuration(stage.estimated)}`
+                      : '—'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PipelineFooter;

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -4,9 +4,11 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { SearchAddon } from '@xterm/addon-search';
 import { useTerminalStore } from '../state/terminal-store';
-import { registerTerminal, unregisterTerminal } from '../terminal-registry';
+import { usePipelineStore } from '../state/pipeline-store';
+import { registerTerminal, unregisterTerminal, getTerminalEntry, addTerminalCleanup, stashTerminal, unstashTerminal, disposeTerminal, setWebglAddon } from '../terminal-registry';
 import { isMac } from '../utils/platform';
 import type { AppConfig } from '../state/types';
+import { PipelineFooter } from './PipelineFooter';
 import '@xterm/xterm/css/xterm.css';
 
 function hexToTerminalRgba(hex: string, alpha: number): string {
@@ -854,6 +856,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
       )}
       {showDiag && <DiagnosticsOverlay terminalId={terminalId} diagRef={diagRef} mainDiag={mainDiagRef.current} logPath={logPathRef.current} onClose={() => setShowDiag(false)} />}
       <div ref={containerRef} className="xterm-container" />
+      <PipelineFooter paneId={terminalId} />
       {bgTint && <div className="terminal-color-overlay" style={{ background: bgTint + '18' }} />}
     </div>
   );

--- a/src/renderer/state/pipeline-store.ts
+++ b/src/renderer/state/pipeline-store.ts
@@ -1,0 +1,59 @@
+/**
+ * Pipeline store — lightweight zustand store for pipeline tracking status.
+ * Receives updates from the main process via IPC and provides state to
+ * the PipelineFooter component.
+ */
+
+import { create } from 'zustand';
+import type { PipelineStatus } from '../../shared/pipeline-types';
+
+interface PipelineState {
+  /** Map of pane ID → current pipeline status (null = no active tracking) */
+  statuses: Record<string, PipelineStatus | null>;
+  /** Set of dismissed pane IDs (user explicitly closed the widget) */
+  dismissed: Set<string>;
+  /** Update status for a pane (called from IPC listener) */
+  setPipelineStatus: (paneId: string, status: PipelineStatus | null) => void;
+  /** Dismiss tracking for a pane */
+  dismissPipeline: (paneId: string) => void;
+}
+
+export const usePipelineStore = create<PipelineState>((set, get) => ({
+  statuses: {},
+  dismissed: new Set(),
+
+  setPipelineStatus: (paneId, status) => {
+    set((state) => {
+      const newStatuses = { ...state.statuses };
+      if (status === null) {
+        delete newStatuses[paneId];
+      } else {
+        newStatuses[paneId] = status;
+      }
+      // If we got a new status, un-dismiss (new pipeline run)
+      const newDismissed = new Set(state.dismissed);
+      if (status !== null) {
+        newDismissed.delete(paneId);
+      }
+      return { statuses: newStatuses, dismissed: newDismissed };
+    });
+  },
+
+  dismissPipeline: (paneId) => {
+    set((state) => ({
+      dismissed: new Set(state.dismissed).add(paneId),
+    }));
+    // Tell main process to clean up the file
+    (window as any).terminalAPI?.dismissPipeline(paneId);
+  },
+}));
+
+/** Initialize IPC listener — call once from App.tsx */
+export function initPipelineIpc(): () => void {
+  const api = (window as any).terminalAPI;
+  if (!api?.onPipelineStatusUpdate) return () => {};
+
+  return api.onPipelineStatusUpdate((paneId: string, status: unknown) => {
+    usePipelineStore.getState().setPipelineStatus(paneId, status as PipelineStatus | null);
+  });
+}

--- a/src/renderer/state/pipeline-store.ts
+++ b/src/renderer/state/pipeline-store.ts
@@ -30,9 +30,10 @@ export const usePipelineStore = create<PipelineState>((set, get) => ({
       } else {
         newStatuses[paneId] = status;
       }
-      // If we got a new status, un-dismiss (new pipeline run)
+      // Only un-dismiss if this is a genuinely new build (different buildId)
       const newDismissed = new Set(state.dismissed);
-      if (status !== null) {
+      const prev = state.statuses[paneId];
+      if (status !== null && (!prev || prev.buildId !== status.buildId)) {
         newDismissed.delete(paneId);
       }
       return { statuses: newStatuses, dismissed: newDismissed };

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -3495,3 +3495,131 @@ select.settings-input {
   outline: none;
   box-sizing: border-box;
 }
+
+/* ===== Pipeline Footer ===== */
+.pipeline-footer {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  font-size: 11px;
+  color: var(--text-primary);
+  contain: layout style;
+  z-index: 5;
+}
+
+.pipeline-footer-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.pipeline-footer-header:hover {
+  background: rgba(137, 180, 250, 0.08);
+}
+
+.pipeline-footer-status {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.pipeline-footer-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+.pipeline-footer-branch {
+  color: var(--text-secondary);
+  font-size: 10px;
+  background: rgba(137, 180, 250, 0.12);
+  padding: 0 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.pipeline-footer-progress-bar {
+  flex: 1;
+  height: 4px;
+  background: rgba(88, 91, 112, 0.5);
+  border-radius: 2px;
+  overflow: hidden;
+  min-width: 40px;
+}
+
+.pipeline-footer-progress-fill {
+  height: 100%;
+  background: #89b4fa;
+  border-radius: 2px;
+  transition: width 0.5s ease;
+}
+
+.pipeline-footer-progress-fill.succeeded {
+  background: #a6e3a1;
+}
+
+.pipeline-footer-progress-fill.failed {
+  background: #f38ba8;
+}
+
+.pipeline-footer-eta {
+  color: var(--text-secondary);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.pipeline-footer-toggle,
+.pipeline-footer-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.pipeline-footer-toggle:hover,
+.pipeline-footer-dismiss:hover {
+  color: var(--text-primary);
+}
+
+.pipeline-footer-stages {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 2px 12px;
+  padding: 2px 8px 4px 8px;
+  border-top: 1px solid rgba(69, 71, 90, 0.5);
+}
+
+.pipeline-footer-stage {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 0;
+}
+
+.pipeline-stage-icon {
+  font-size: 10px;
+  flex-shrink: 0;
+  width: 12px;
+  text-align: center;
+}
+
+.pipeline-stage-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.pipeline-stage-time {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -54,6 +54,9 @@ export const IPC = {
   // ── File explorer ──────────────────────────────────────────────────
   FILE_LIST: 'file:list',
   FILE_READ: 'file:read',
+  // ── Pipeline tracker ────────────────────────────────────────────
+  PIPELINE_STATUS_UPDATE: 'pipeline:statusUpdate',
+  PIPELINE_DISMISS: 'pipeline:dismiss',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/src/shared/pipeline-types.ts
+++ b/src/shared/pipeline-types.ts
@@ -1,0 +1,26 @@
+/** Stage-level status for a pipeline run */
+export interface PipelineStage {
+  name: string;
+  state: 'pending' | 'inProgress' | 'completed' | 'skipped' | 'cancelling';
+  result: 'succeeded' | 'failed' | 'canceled' | 'skipped' | null;
+  /** Elapsed seconds (only when inProgress or completed) */
+  duration?: number;
+  /** Elapsed seconds so far (only when inProgress) */
+  elapsed?: number;
+  /** Estimated total seconds (from historical average) */
+  estimated?: number;
+}
+
+/** Full status payload written by the monitor script and sent to renderer */
+export interface PipelineStatus {
+  buildId: number;
+  pipelineName: string;
+  sourceBranch: string;
+  status: 'notStarted' | 'inProgress' | 'completed' | 'cancelling';
+  result: 'succeeded' | 'failed' | 'canceled' | null;
+  stages: PipelineStage[];
+  startTime: string;
+  /** Estimated remaining seconds */
+  estimatedRemaining: number | null;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Pipeline Tracker

Adds a pane-level footer widget that shows real-time ADO pipeline progress directly on the terminal pane where the AI is working.

### Architecture
- **AI-driven**: The AI triggers the pipeline via MCP tools, then launches a background monitor script
- **Side-channel communication**: Status data flows via filesystem (`~/.tmax/pipeline/`), not through the terminal stream
- **No ADO config in tmax**: The AI already has ADO credentials via MCP tools

### How it works
1. AI triggers a pipeline and runs `tmax-pipeline-monitor --build-id 1234 --org ... --project ... --pat $TOKEN &`
2. Monitor script polls ADO REST API every 15s, writes status JSON to `~/.tmax/pipeline/{paneId}.json`
3. Main process watches the directory via `fs.watch`, sends IPC updates to renderer
4. `PipelineFooter` component renders at bottom of the specific terminal pane

### UI
- Shows pipeline name, branch, progress bar with stage completion, ETA
- Expandable to show individual stage details with icons (✓/●/○/✗)
- Dismiss button to hide
- Only visible when pipeline data exists for the pane

### Files
- `scripts/tmax-pipeline-monitor.js` — background ADO polling script
- `src/shared/pipeline-types.ts` — TypeScript interfaces
- `src/main/pipeline-watcher.ts` — main-process file watcher
- `src/renderer/state/pipeline-store.ts` — zustand store
- `src/renderer/components/PipelineFooter.tsx` — footer widget
- Modified: pty-manager, ipc-channels, preload, main, TerminalPanel, App, global.css