### PR TITLE
fix: correct node-pty copy path for macOS DMG builds

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,28 +11,25 @@ const config: ForgeConfig = {
   outDir: process.env.FORGE_OUT_DIR || 'out',
   hooks: {
     postPackage: async (_config, options) => {
-      // Copy node-pty native module into packaged app
       const path = require('path');
       const fs = require('fs-extra');
-      const outputPath = options.outputPaths[0];
-      // macOS: Contents/Resources/app, Windows/Linux: resources/app
-      const isMac = outputPath.endsWith('.app') || outputPath.includes('.app/');
-      const appDir = isMac
-        ? path.join(outputPath, 'Contents', 'Resources', 'app')
-        : path.join(outputPath, 'resources', 'app');
-      // Fallback: try .vite path structure
-      const appDirVite = isMac
-        ? path.join(outputPath, 'Contents', 'Resources', 'app.vite')
-        : null;
-      const targetDir = fs.existsSync(appDir) ? appDir : (appDirVite && fs.existsSync(appDirVite) ? appDirVite : appDir);
+      const outDir = options.outputPaths[0];
+
+      // On macOS, outputPaths[0] is the directory containing the .app bundle
+      // (e.g. out/tmax-darwin-arm64), not the .app itself.
+      const macApp = fs.readdirSync(outDir).find((f: string) => f.endsWith('.app'));
+      const appDir = macApp
+        ? path.join(outDir, macApp, 'Contents', 'Resources', 'app')
+        : path.join(outDir, 'resources', 'app');
+
       const src = path.join(__dirname, 'node_modules', 'node-pty');
-      const dest = path.join(targetDir, 'node_modules', 'node-pty');
+      const dest = path.join(appDir, 'node_modules', 'node-pty');
       await fs.copy(src, dest);
-      // Also copy node-addon-api (node-pty dependency)
+
       const napiSrc = path.join(__dirname, 'node_modules', 'node-addon-api');
-      const napiDest = path.join(targetDir, 'node_modules', 'node-addon-api');
+      const napiDest = path.join(appDir, 'node_modules', 'node-addon-api');
       if (fs.existsSync(napiSrc)) await fs.copy(napiSrc, napiDest);
-      console.log(`Copied node-pty to packaged app: ${targetDir}`);
+      console.log(`Copied node-pty native module to ${appDir}`);
     },
   },
   packagerConfig: {


### PR DESCRIPTION
## Problem
The packaged DMG crashes on launch with `Cannot find module 'node-pty'`.

## Root Cause
The `postPackage` hook in `forge.config.ts` checked `outputPaths[0].endsWith('.app')` to detect macOS — but Electron Forge sets `outputPaths[0]` to the **parent directory** (e.g. `out/tmax-darwin-arm64`), not the `.app` bundle itself. So `isMac` was always `false`, and `node-pty` was copied to `out/tmax-darwin-arm64/resources/app/` instead of `out/tmax-darwin-arm64/tmax.app/Contents/Resources/app/`.

## Fix
Scan the output directory for a `.app` bundle and construct the correct path. Falls back to `resources/app` for Windows/Linux.