### PR TITLE
feat: add toggle to show/hide tab close buttons

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -448,12 +448,11 @@ const AppearanceSettings: React.FC = () => {
         </div>
       </SettingRow>
       <SettingRow label="Show Tab Close Buttons" description="Hide close buttons to avoid accidentally closing tabs">
-        <button
-          className={`settings-toggle${(config as any).showTabCloseButtons !== false ? ' active' : ''}`}
-          onClick={() => useTerminalStore.getState().toggleShowTabCloseButtons()}
-        >
-          {(config as any).showTabCloseButtons !== false ? 'On' : 'Off'}
-        </button>
+        <label className="toggle-switch">
+          <input type="checkbox" checked={(config as any).showTabCloseButtons !== false}
+            onChange={() => useTerminalStore.getState().toggleShowTabCloseButtons()} />
+          <span className="toggle-track" />
+        </label>
       </SettingRow>
       <SettingRow label="Default Tab Color" description="Background tint for all terminals without a custom color">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -447,6 +447,14 @@ const AppearanceSettings: React.FC = () => {
           })()}
         </div>
       </SettingRow>
+      <SettingRow label="Show Tab Close Buttons" description="Hide close buttons to avoid accidentally closing tabs">
+        <button
+          className={`settings-toggle${(config as any).showTabCloseButtons !== false ? ' active' : ''}`}
+          onClick={() => useTerminalStore.getState().toggleShowTabCloseButtons()}
+        >
+          {(config as any).showTabCloseButtons !== false ? 'On' : 'Off'}
+        </button>
+      </SettingRow>
       <SettingRow label="Default Tab Color" description="Background tint for all terminals without a custom color">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <input type="color" className="theme-color-picker"

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -63,6 +63,7 @@ const Tab: React.FC<TabProps> = ({
   const isSelected = useTerminalStore((s) => !!s.selectedTerminalIds[terminalId]);
   const isInGrid = useTerminalStore((s) => !!s.gridTabIds[terminalId]);
   const viewMode = useTerminalStore((s) => s.viewMode);
+  const showCloseBtn = useTerminalStore((s) => s.showTabCloseButtons);
 
   // Check if this tab's AI session needs attention.
   // Selector returns a primitive string so Zustand skips re-render when status is unchanged.
@@ -156,9 +157,11 @@ const Tab: React.FC<TabProps> = ({
           <span className="tab-title">{title}</span>
         </>
       )}
-      <button className="close-btn" onClick={handleCloseClick} title="Close">
-        &#10005;
-      </button>
+      {showCloseBtn && (
+        <button className="close-btn" onClick={handleCloseClick} title="Close">
+          &#10005;
+        </button>
+      )}
     </div>
   );
 };

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -512,6 +512,7 @@ interface TerminalStore {
   showSettings: boolean;
   tabBarPosition: 'top' | 'bottom' | 'left' | 'right';
   hideTabTitles: boolean;
+  showTabCloseButtons: boolean;
   renamingTerminalId: TerminalId | null;
   viewMode: 'split' | 'focus' | 'grid';
   gridColumns: number; // 0 = auto (sqrt-based), 1..N = fixed column count
@@ -581,6 +582,7 @@ interface TerminalStore {
   updateConfig: (update: Partial<AppConfig>) => Promise<void>;
   toggleTabBarPosition: () => void;
   toggleHideTabTitles: () => void;
+  toggleShowTabCloseButtons: () => void;
   setTerminalOpacity: (opacity: number) => void;
   startRenaming: (id: TerminalId | null) => void;
   toggleViewMode: () => void;
@@ -685,6 +687,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   recentDirs: [],
   tabBarPosition: 'top' as 'top' | 'bottom' | 'left' | 'right',
   hideTabTitles: false,
+  showTabCloseButtons: true,
   renamingTerminalId: null,
   viewMode: 'grid' as 'split' | 'focus' | 'grid',
   gridColumns: 0,
@@ -704,6 +707,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     const updates: Record<string, unknown> = { config };
     if (config?.tabBarPosition) updates.tabBarPosition = config.tabBarPosition;
     if (typeof (config as any)?.hideTabTitles === 'boolean') updates.hideTabTitles = (config as any).hideTabTitles;
+    if (typeof (config as any)?.showTabCloseButtons === 'boolean') updates.showTabCloseButtons = (config as any).showTabCloseButtons;
     if ((config as any)?.terminalOpacity != null) {
       updates.terminalOpacity = (config as any).terminalOpacity;
       document.documentElement.style.setProperty('--terminal-opacity', String((config as any).terminalOpacity));
@@ -1469,6 +1473,12 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     const val = !get().hideTabTitles;
     set({ hideTabTitles: val });
     get().updateConfig({ hideTabTitles: val } as any);
+  },
+
+  toggleShowTabCloseButtons: () => {
+    const val = !get().showTabCloseButtons;
+    set({ showTabCloseButtons: val });
+    get().updateConfig({ showTabCloseButtons: val } as any);
   },
 
   setTerminalOpacity: (opacity: number) => {

--- a/src/renderer/state/types.ts
+++ b/src/renderer/state/types.ts
@@ -112,6 +112,7 @@ export interface AppConfig {
   copilotCommand?: string;
   claudeCodeCommand?: string;
   tabBarPosition?: 'top' | 'bottom' | 'left' | 'right';
+  showTabCloseButtons?: boolean;
   backgroundMaterial?: BackgroundMaterial;
   backgroundOpacity?: number; // 0.0–1.0, default 0.8
 }

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -2172,6 +2172,48 @@ select.settings-input {
   font-weight: 600;
 }
 
+/* Slide toggle switch */
+.toggle-switch {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
+.toggle-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 11px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  transition: background 0.2s, border-color 0.2s;
+}
+.toggle-switch input:checked + .toggle-track {
+  background: var(--focus-border);
+  border-color: var(--focus-border);
+}
+.toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  transition: transform 0.2s, background 0.2s;
+}
+.toggle-switch input:checked + .toggle-track::after {
+  transform: translateX(18px);
+  background: var(--bg-primary);
+}
+
 /* Font face combo box */
 .font-combobox {
   position: relative;


### PR DESCRIPTION
## Summary

Adds a **Show Tab Close Buttons** toggle in the Appearance settings that lets users hide the ✕ buttons on tabs. This prevents accidental tab closes when clicking to switch between tabs, which is a common pain point when working with many open tabs.

The setting is **enabled by default** so existing behaviour is preserved.

---

## Changes

- **Settings UI** – New toggle in the Appearance section labelled *Show Tab Close Buttons*
- **TabBar** – Conditionally renders the close button based on the setting
- **State** – Adds `showTabCloseButtons` to the terminal store (persisted across sessions)
- **Styles** – Replaces the plain On/Off button with a smooth sliding toggle switch

---

## Screenshots

### Appearance Settings — Toggle
<img width="611" height="510" alt="settings to toggle showing X" src="https://github.com/user-attachments/assets/7ebc3e95-1f92-4315-a9a6-a651b1f57b08" />


### Tabs without the ✕ button
<img width="684" height="144" alt="tabs without X for closing" src="https://github.com/user-attachments/assets/1cf36b01-d197-49a6-b69d-47206f2031f6" />

---

## Testing

- [ ] Toggle is **on** by default; tabs show ✕ as before
- [ ] Turning the toggle **off** hides the ✕ on all open tabs
- [ ] Setting persists after closing and reopening the app
- [ ] Toggling while tabs are open updates the UI immediately (no reload needed)