### PR TITLE
fix: guard session auto-reactivation to linked terminals only

### DIFF
--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -2135,14 +2135,17 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       copilotSessions: s.copilotSessions.map((x) => (x.id === session.id ? session : x)),
     }));
     get().updateTerminalTitleFromSession(session, 'copilot');
-    // Auto-reactivate if session was completed/old and has new activity
+    // Auto-reactivate only if session has a linked terminal in tmax
     const lifecycle = get().sessionLifecycleOverrides[session.id];
     if ((lifecycle === 'completed' || lifecycle === 'old') && oldSession) {
-      const hasNewActivity = session.status !== 'idle' || session.messageCount > oldSession.messageCount;
-      if (hasNewActivity) {
-        get().setSessionLifecycle(session.id, 'active');
-        const name = get().sessionNameOverrides[session.id] || session.summary || session.id.slice(0, 8);
-        get().addToast(`"${name}" moved back to Active`);
+      const hasLinkedTerminal = [...get().terminals.values()].some((t) => t.aiSessionId === session.id);
+      if (hasLinkedTerminal) {
+        const hasNewActivity = session.status !== 'idle' || session.messageCount > oldSession.messageCount;
+        if (hasNewActivity) {
+          get().setSessionLifecycle(session.id, 'active');
+          const name = get().sessionNameOverrides[session.id] || session.summary || session.id.slice(0, 8);
+          get().addToast(`"${name}" moved back to Active`);
+        }
       }
     }
   },
@@ -2187,14 +2190,17 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       claudeCodeSessions: s.claudeCodeSessions.map((x) => (x.id === session.id ? session : x)),
     }));
     get().updateTerminalTitleFromSession(session, 'claude');
-    // Auto-reactivate if session was completed/old and has new activity
+    // Auto-reactivate only if session has a linked terminal in tmax
     const lifecycle = get().sessionLifecycleOverrides[session.id];
     if ((lifecycle === 'completed' || lifecycle === 'old') && oldSession) {
-      const hasNewActivity = session.status !== 'idle' || session.messageCount > oldSession.messageCount;
-      if (hasNewActivity) {
-        get().setSessionLifecycle(session.id, 'active');
-        const name = get().sessionNameOverrides[session.id] || session.summary || session.id.slice(0, 8);
-        get().addToast(`"${name}" moved back to Active`);
+      const hasLinkedTerminal = [...get().terminals.values()].some((t) => t.aiSessionId === session.id);
+      if (hasLinkedTerminal) {
+        const hasNewActivity = session.status !== 'idle' || session.messageCount > oldSession.messageCount;
+        if (hasNewActivity) {
+          get().setSessionLifecycle(session.id, 'active');
+          const name = get().sessionNameOverrides[session.id] || session.summary || session.id.slice(0, 8);
+          get().addToast(`"${name}" moved back to Active`);
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary

Fixes session lifecycle overrides (completed/old) being unexpectedly reverted to active when external Copilot/Claude activity is detected outside tmax (e.g. in iTerm).

## What Changed

- **Auto-reactivation guard** — `updateCopilotSession` and `updateClaudeCodeSession` now check if the session has a linked terminal in tmax before auto-reactivating. External session activity no longer corrupts lifecycle states.

## Root Cause

The session watchers detect ANY Copilot/Claude activity on the filesystem. When a session marked as completed/old showed new activity (even from another terminal app), tmax would flip it back to active. This fix ensures only sessions with an open terminal in tmax are candidates for reactivation.