### PR TITLE
feat: paste URL from HTML clipboard when content is a single link

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -30,6 +30,7 @@ export interface TerminalAPI {
   getConfig(): Promise<Record<string, unknown>>;
   setConfig(key: string, value: unknown): Promise<void>;
   clipboardRead(): string;
+  clipboardReadHTML(): string;
   clipboardWrite(text: string): void;
   clipboardHasImage(): boolean;
   clipboardSaveImage(): Promise<string>;
@@ -101,6 +102,10 @@ const terminalAPI: TerminalAPI = {
 
   clipboardRead() {
     return clipboard.readText();
+  },
+
+  clipboardReadHTML() {
+    return clipboard.readHTML();
   },
 
   clipboardWrite(text: string) {

--- a/src/renderer/DetachedApp.tsx
+++ b/src/renderer/DetachedApp.tsx
@@ -5,6 +5,23 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { isMac } from './utils/platform';
 import '@xterm/xterm/css/xterm.css';
 
+/**
+ * Extract a URL from HTML clipboard content when the content is essentially
+ * a single hyperlink (e.g. ADO "Copy to clipboard" for PR titles).
+ * Returns the href if found, null otherwise.
+ */
+function extractLinkFromHtml(html: string): string | null {
+  if (!html) return null;
+  const linkPattern = /<a\s[^>]*href=["']([^"']+)["'][^>]*>/gi;
+  const matches: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = linkPattern.exec(html)) !== null) {
+    matches.push(m[1]);
+  }
+  if (matches.length === 1) return matches[0];
+  return null;
+}
+
 function hexToTerminalRgba(hex: string, alpha: number): string {
   const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   if (!m) return hex;
@@ -77,12 +94,18 @@ const DetachedApp: React.FC<DetachedAppProps> = ({ terminalId }) => {
               window.terminalAPI.writePty(terminalId, filePath);
             });
           } else {
-            navigator.clipboard
-              .readText()
-              .then((text) => {
-                if (text) window.terminalAPI.writePty(terminalId, text);
-              })
-              .catch(() => {});
+            const html = window.terminalAPI.clipboardReadHTML();
+            const linkUrl = extractLinkFromHtml(html);
+            if (linkUrl) {
+              window.terminalAPI.writePty(terminalId, linkUrl);
+            } else {
+              navigator.clipboard
+                .readText()
+                .then((text) => {
+                  if (text) window.terminalAPI.writePty(terminalId, text);
+                })
+                .catch(() => {});
+            }
           }
           return false;
         }

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -9,6 +9,25 @@ import { isMac } from '../utils/platform';
 import type { AppConfig } from '../state/types';
 import '@xterm/xterm/css/xterm.css';
 
+/**
+ * Extract a URL from HTML clipboard content when the content is essentially
+ * a single hyperlink (e.g. ADO "Copy to clipboard" for PR titles).
+ * Returns the href if found, null otherwise.
+ */
+function extractLinkFromHtml(html: string): string | null {
+  if (!html) return null;
+  // Match all <a href="..."> tags in the HTML
+  const linkPattern = /<a\s[^>]*href=["']([^"']+)["'][^>]*>/gi;
+  const matches: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = linkPattern.exec(html)) !== null) {
+    matches.push(m[1]);
+  }
+  // Only extract when the HTML contains exactly one link
+  if (matches.length === 1) return matches[0];
+  return null;
+}
+
 function hexToTerminalRgba(hex: string, alpha: number): string {
   const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   if (!m) return hex;
@@ -264,7 +283,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
             window.terminalAPI.writePty(terminalId, filePath);
           });
         } else {
-          const text = window.terminalAPI.clipboardRead();
+          const html = window.terminalAPI.clipboardReadHTML();
+          const linkUrl = extractLinkFromHtml(html);
+          const text = linkUrl || window.terminalAPI.clipboardRead();
           if (text) window.terminalAPI.writePty(terminalId, text);
         }
         return false;
@@ -579,7 +600,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
             window.terminalAPI.writePty(terminalId, filePath);
           });
         } else {
-          const text = window.terminalAPI.clipboardRead();
+          const html = window.terminalAPI.clipboardReadHTML();
+          const linkUrl = extractLinkFromHtml(html);
+          const text = linkUrl || window.terminalAPI.clipboardRead();
           if (text) window.terminalAPI.writePty(terminalId, text);
         }
       }


### PR DESCRIPTION
Fixes #52

## Problem

When copying a PR title from ADO using the "Copy to clipboard" button, the clipboard contains both plain text and HTML with an embedded `<a href>` hyperlink. tmax only read `clipboard.readText()`, losing the URL.

## Solution

On paste, check `clipboard.readHTML()` for anchor tags. If the HTML contains exactly one `<a href>` link, paste the URL instead of the plain text. Otherwise, fall back to plain text (no behavior change for normal paste).

This makes pasted links clickable via xterm's WebLinksAddon.

## Changes

| File | Change |
|------|--------|
| `src/preload/preload.ts` | Add `clipboardReadHTML()` to the preload API |
| `src/renderer/components/TerminalPanel.tsx` | Extract URL from HTML on paste (Ctrl+V and right-click) |
| `src/renderer/DetachedApp.tsx` | Same logic for detached terminal windows |

## Design decisions

- **Single-link only**: Only extracts the URL when the HTML contains exactly one `<a>` tag. Multi-link HTML (e.g. rich document copy) falls back to plain text — avoids surprising behavior.
- **No new dependencies**: Uses a simple regex to extract `href` values. No DOM parser needed for this use case.
- **Shared helper**: `extractLinkFromHtml()` is defined in both TerminalPanel and DetachedApp (they don't share a utils module currently).