### PR TITLE
security: remove PTY write preview from diagnostic logs

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -167,7 +167,7 @@ export class PtyManager {
     if (pty) {
       const s = this.stats.get(id);
       if (s) { s.writeCount++; s.lastWriteTime = Date.now(); }
-      diagLog('pty:write', { id, bytes: data.length, preview: sanitize(data) });
+      diagLog('pty:write', { id, bytes: data.length });
       pty.write(data);
     } else {
       diagLog('pty:write:no-pty', { id, bytes: data.length });


### PR DESCRIPTION
The `preview` field in the PTY write diagnostic log (`tmax-diag.log`) logged the first 40 characters of every keystroke written to the terminal. This captures passwords, tokens, and other sensitive data typed into terminals (ssh, sudo, etc.).

This PR removes the `preview` field from the log entry, keeping only `id` and `bytes` for diagnostics.

Part of #54