### PR TITLE
security: validate URL protocol in clipboard paste

### DIFF
--- a/src/renderer/DetachedApp.tsx
+++ b/src/renderer/DetachedApp.tsx
@@ -18,7 +18,7 @@ function extractLinkFromHtml(html: string): string | null {
   while ((m = linkPattern.exec(html)) !== null) {
     matches.push(m[1]);
   }
-  if (matches.length === 1) return matches[0];
+  if (matches.length === 1 && /^https?:\/\//i.test(matches[0])) return matches[0];
   return null;
 }
 

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -24,7 +24,7 @@ function extractLinkFromHtml(html: string): string | null {
     matches.push(m[1]);
   }
   // Only extract when the HTML contains exactly one link
-  if (matches.length === 1) return matches[0];
+  if (matches.length === 1 && /^https?:\/\//i.test(matches[0])) return matches[0];
   return null;
 }
 


### PR DESCRIPTION
Only extract URLs with `http`/`https` protocol from HTML clipboard content in `extractLinkFromHtml()`.

Rejects `javascript:`, `data:`, and `file:` URIs that could be used for social engineering attacks when pasted into the terminal.

Part of #54