### PR TITLE
security: add path traversal guard to git-diff-service

### DIFF
--- a/src/main/git-diff-service.ts
+++ b/src/main/git-diff-service.ts
@@ -300,14 +300,17 @@ export class GitDiffService {
     if (!raw.trim()) {
       // No diff — file is unmodified or untracked; read as-is
       try {
-        const content = await readFile(path.join(root, filePath), 'utf-8');
+        const resolvedPath = path.resolve(root, filePath);
+        if (!resolvedPath.startsWith(path.resolve(root))) throw new Error('Path traversal detected');
+        const content = await readFile(resolvedPath, 'utf-8');
         const lines: AnnotatedLine[] = content.split('\n').map((line, i) => ({
           lineNumber: i + 1,
           content: line,
           type: 'unchanged' as DiffLineType,
         }));
         return { path: filePath, lines };
-      } catch {
+      } catch (e) {
+        if (e instanceof Error && e.message === 'Path traversal detected') throw e;
         return { path: filePath, lines: [] };
       }
     }
@@ -316,7 +319,9 @@ export class GitDiffService {
     const diffs = this.parseDiff(raw);
     const fileDiff = diffs[0];
     if (!fileDiff || fileDiff.hunks.length === 0) {
-      const content = await readFile(path.join(root, filePath), 'utf-8');
+      const resolvedPath = path.resolve(root, filePath);
+      if (!resolvedPath.startsWith(path.resolve(root))) throw new Error('Path traversal detected');
+      const content = await readFile(resolvedPath, 'utf-8');
       const lines: AnnotatedLine[] = content.split('\n').map((line, i) => ({
         lineNumber: i + 1,
         content: line,


### PR DESCRIPTION
## Summary

Add path traversal guard to `git-diff-service.ts` to prevent reading files outside the git root via `../../` segments in file paths.

## Problem

`readFileContent` and `getAnnotatedFile` used `path.join(root, filePath)` which does **not** prevent `../` traversal - an attacker-controlled `filePath` could escape the repository root and read arbitrary files on disk.

## Fix

- Replace `path.join` with `path.resolve` (collapses `../` segments)
- Add `startsWith(path.resolve(root))` check after resolution
- Throw `'Path traversal detected'` if the resolved path escapes the git root
- Applied to all 3 call sites: `readFileContent`, and two fallback paths in `getAnnotatedFile`

Part of #54