### PR TITLE
security: restrict shell.openPath to safe extensions and home directory

### DIFF
--- a/src/main/git-diff-service.ts
+++ b/src/main/git-diff-service.ts
@@ -300,14 +300,17 @@ export class GitDiffService {
     if (!raw.trim()) {
       // No diff — file is unmodified or untracked; read as-is
       try {
-        const content = await readFile(path.join(root, filePath), 'utf-8');
+        const resolvedPath = path.resolve(root, filePath);
+        if (!resolvedPath.startsWith(path.resolve(root))) throw new Error('Path traversal detected');
+        const content = await readFile(resolvedPath, 'utf-8');
         const lines: AnnotatedLine[] = content.split('\n').map((line, i) => ({
           lineNumber: i + 1,
           content: line,
           type: 'unchanged' as DiffLineType,
         }));
         return { path: filePath, lines };
-      } catch {
+      } catch (e) {
+        if (e instanceof Error && e.message === 'Path traversal detected') throw e;
         return { path: filePath, lines: [] };
       }
     }
@@ -316,7 +319,9 @@ export class GitDiffService {
     const diffs = this.parseDiff(raw);
     const fileDiff = diffs[0];
     if (!fileDiff || fileDiff.hunks.length === 0) {
-      const content = await readFile(path.join(root, filePath), 'utf-8');
+      const resolvedPath = path.resolve(root, filePath);
+      if (!resolvedPath.startsWith(path.resolve(root))) throw new Error('Path traversal detected');
+      const content = await readFile(resolvedPath, 'utf-8');
       const lines: AnnotatedLine[] = content.split('\n').map((line, i) => ({
         lineNumber: i + 1,
         content: line,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -411,7 +411,15 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(IPC.OPEN_PATH, (_event, filePath: string) => {
-    shell.openPath(filePath);
+    const resolved = path.resolve(filePath);
+    const homeDir = os.homedir();
+    // Block executable extensions that could lead to code execution
+    const blockedExtensions = ['.exe', '.bat', '.cmd', '.ps1', '.sh', '.msi', '.app', '.com', '.vbs', '.wsf', '.jar'];
+    const ext = path.extname(resolved).toLowerCase();
+    if (blockedExtensions.includes(ext)) return;
+    // Restrict to paths under the user's home directory
+    if (!resolved.startsWith(homeDir)) return;
+    shell.openPath(resolved);
   });
 
   ipcMain.handle(IPC.SESSION_LOAD, () => {


### PR DESCRIPTION
## Summary

The `OPEN_PATH` IPC handler previously accepted any arbitrary file path from the renderer process, allowing a compromised renderer to open executables (`.exe`, `.bat`, `.ps1`, etc.) or access files outside the user's home directory (including UNC paths).

## Changes

- **Block executable extensions**: Rejects files with dangerous extensions (`.exe`, `.bat`, `.cmd`, `.ps1`, `.sh`, `.msi`, `.app`, `.com`, `.vbs`, `.wsf`, `.jar`)
- **Restrict to home directory**: Only allows opening paths under `os.homedir()`, preventing traversal to system directories or UNC paths

## Testing

Manual verification - the handler silently returns without opening blocked paths.

Part of #54