### PR TITLE
security: confine FILE_READ and FILE_LIST to user home directory

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -659,6 +659,9 @@ function registerIpcHandlers(): void {
         if (!/^[\w][\w.\-]*$/.test(wslDistro)) return [];
         fsPath = `\\\\wsl.localhost\\${wslDistro}${dirPath.replace(/\//g, '\\')}`;
       }
+      // Confine to user's home directory to prevent arbitrary filesystem enumeration
+      const resolvedDir = path.resolve(fsPath);
+      if (!resolvedDir.startsWith(os.homedir()) && !resolvedDir.startsWith('\\\\wsl.localhost\\')) return [];
       const entries = fs.readdirSync(fsPath, { withFileTypes: true });
       return entries
         .map((e: any) => ({
@@ -684,6 +687,9 @@ function registerIpcHandlers(): void {
         if (!/^[\w][\w.\-]*$/.test(wslDistro)) return null;
         fsPath = `//wsl.localhost/${wslDistro}${filePath}`;
       }
+      // Confine to user's home directory to prevent arbitrary file reads
+      const resolvedFile = path.resolve(fsPath);
+      if (!resolvedFile.startsWith(os.homedir()) && !resolvedFile.startsWith('//wsl.localhost/')) return null;
       const stat = fs.statSync(fsPath);
       // Only read text files under 1MB
       if (stat.size > 1024 * 1024) return null;


### PR DESCRIPTION
## Summary

`FILE_READ` and `FILE_LIST` IPC handlers previously accepted any path from the renderer, allowing a compromised renderer to read any file or enumerate any directory on the system. This change restricts filesystem access to the user's home directory (and WSL UNC paths for WSL terminals).

### Changes

- **`IPC.FILE_LIST`**: Added `path.resolve()` + `os.homedir()` prefix check before `fs.readdirSync`. WSL paths (`\\\\wsl.localhost\\`) are allowed.
- **`IPC.FILE_READ`**: Added `path.resolve()` + `os.homedir()` prefix check before `fs.statSync`. WSL paths (`//wsl.localhost/`) are allowed.

Both handlers return early (empty array / null) for paths outside the allowed prefixes.

Part of #54