### PR TITLE
security: validate shell paths in CONFIG_SET handler

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -387,6 +387,17 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     IPC.CONFIG_SET,
     (_event, key: string, value: unknown) => {
+      // Validate shell paths exist on disk to prevent injection of arbitrary executables
+      if (key === 'shells' && Array.isArray(value)) {
+        for (const shell of value) {
+          if (shell && typeof shell === 'object' && 'path' in shell) {
+            if (typeof shell.path !== 'string' || !fs.existsSync(shell.path)) {
+              throw new Error(`Invalid shell path: ${shell.path}`);
+            }
+          }
+        }
+      }
+
       configStore!.set(key as keyof ReturnType<ConfigStore['getAll']>, value as never);
 
       // Dynamically apply background material changes


### PR DESCRIPTION
The CONFIG_SET IPC handler allowed the renderer to set arbitrary shell profiles, which could then bypass PTY_CREATE shell path allowlist. Now validates that shell paths exist on disk before saving to config.

Part of #54

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>