### PR TITLE
fix: macOS directory tracking — zsh precmd hook + correct path parsing

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -103,8 +103,9 @@ export class PtyManager {
     const shellName = opts.shellPath.toLowerCase();
     const shellEnv: Record<string, string> = { TERM_PROGRAM: 'tmax', COLORTERM: 'truecolor' };
 
-    // Set PROMPT_COMMAND via env var for native bash/zsh (not WSL — shell init takes longer)
-    if (!shellName.includes('wsl') && (shellName.includes('bash') || shellName.includes('zsh'))) {
+    // Set PROMPT_COMMAND via env var for native bash (not WSL — shell init takes longer)
+    // zsh doesn't support PROMPT_COMMAND; it uses precmd hooks injected below via PTY write
+    if (!shellName.includes('wsl') && shellName.includes('bash') && !shellName.includes('zsh')) {
       shellEnv.PROMPT_COMMAND = 'printf "\\e]7;file:///%s\\a" "$(pwd)"';
     }
 
@@ -140,6 +141,14 @@ export class PtyManager {
       setTimeout(() => ptyProcess.write('cls\r'), 400);
     }
     // CMD: relies on prompt regex fallback (no hook mechanism)
+
+    // Inject shell integration for zsh (precmd hook for OSC 7)
+    // zsh doesn't support PROMPT_COMMAND; use precmd_functions array instead
+    if (!shellName.includes('wsl') && shellName.includes('zsh') && !shellName.includes('pwsh')) {
+      const zshSnippet = `__tmax_precmd() { printf '\\e]7;file:///%s\\a' "$PWD" }; precmd_functions+=(__tmax_precmd)`;
+      setTimeout(() => ptyProcess.write(zshSnippet + '\r'), 200);
+      setTimeout(() => ptyProcess.write('clear\r'), 400);
+    }
 
     ptyProcess.onData((data) => {
       const s = this.stats.get(opts.id);

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -419,8 +419,16 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
           const osc7Match = data.match(/\x1b\]7;file:\/\/[^/]*\/([^\x07\x1b]+)(?:\x07|\x1b\\)/);
           if (osc7Match) {
             const decoded = decodeURIComponent(osc7Match[1]);
-            // For WSL terminals, keep Linux-style forward slashes; prefix with / for absolute path
-            detectedDir = isWsl ? '/' + decoded : decoded.replace(/\//g, '\\');
+            if (isWsl) {
+              // WSL: keep Linux-style forward slashes; prefix with / for absolute path
+              detectedDir = '/' + decoded;
+            } else if (/^[A-Za-z]:/.test(decoded)) {
+              // Windows path (C:/Users/...) — convert to backslashes
+              detectedDir = decoded.replace(/\//g, '\\');
+            } else {
+              // macOS/Linux path — keep forward slashes, ensure leading /
+              detectedDir = decoded.startsWith('/') ? decoded : '/' + decoded;
+            }
           }
 
           // Try OSC 9;9 (Windows Terminal / ConPTY)


### PR DESCRIPTION
Two bugs prevented CWD tracking on macOS:
 
 1. **PROMPT_COMMAND doesn't work in zsh** (macOS default) — now injects a precmd hook via 
PTY write
 2. **OSC 7 path parser mangled macOS paths** (/Users/foo → \Users\foo) — now detects 
Windows paths by drive letter