### PR TITLE
feat: auto-changelog, in-app changelog modal, and website full changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,118 @@ name: Build and Release
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
+  prepare-release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+      sha: ${{ steps.push.outputs.sha }}
+      changelog_section: ${{ steps.changelog.outputs.section }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: version
+        run: |
+          OLD_VERSION=$(node -p "require('./package.json').version")
+          npm version ${{ inputs.bump }} --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "old_version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Bumped ${OLD_VERSION} → ${NEW_VERSION}"
+
+      - name: Sync package-lock.json
+        run: npm install --package-lock-only
+
+      - name: Generate changelog section
+        id: changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DATE=$(date +%Y-%m-%d)
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          # Use GitHub API to get commits with resolved author usernames
+          REPO="${{ github.repository }}"
+          if [ -n "$LAST_TAG" ]; then
+            COMMITS=$(gh api "/repos/${REPO}/compare/${LAST_TAG}...HEAD" \
+              --jq '.commits[]
+                | select(.parents | length == 1)
+                | select(.commit.message | startswith("chore: download stats snapshot") | not)
+                | "- \(.commit.message | split("\n")[0]) (\(if .author.login then "@\(.author.login)" else .commit.author.name end))"' \
+              || true)
+          else
+            COMMITS=$(git log --pretty=format:"- %s (%aN)" --no-merges \
+              | grep -v "^- chore: download stats snapshot" || true)
+          fi
+          : "${COMMITS:=- Maintenance and improvements}"
+
+          SECTION="## v${VERSION} - ${DATE}
+
+          ${COMMITS}"
+          echo "$SECTION" > /tmp/changelog_section.md
+
+          # Prepend new section to CHANGELOG.md (after header line)
+          if [ -f CHANGELOG.md ]; then
+            { head -1 CHANGELOG.md; echo; echo "$SECTION"; echo; tail -n +2 CHANGELOG.md; } > /tmp/changelog_new.md
+            mv /tmp/changelog_new.md CHANGELOG.md
+          else
+            printf '# Changelog\n\n%s\n' "$SECTION" > CHANGELOG.md
+          fi
+
+          # Output for release body (heredoc for multiline)
+          {
+            echo "section<<CHANGELOG_EOF"
+            cat /tmp/changelog_section.md
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Commit and tag
+        id: push
+        run: |
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore(release): v${{ steps.version.outputs.version }} [skip ci]"
+          git pull --rebase origin main
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin main --follow-tags
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: [prepare-release]
+    if: always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped')
     strategy:
       matrix:
         include:
@@ -35,6 +139,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -49,21 +155,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y dpkg fakeroot rpm libx11-dev libxkbfile-dev
 
-      # Generate macOS icon (icns) from png
+      # Generate macOS icon (icns) from png using standard iconset sizes
       - name: Generate macOS icon
         if: matrix.platform == 'darwin'
         run: |
           mkdir -p assets/icon.iconset
-          sips -z 16 16     assets/icon.png --out assets/icon.iconset/icon_16x16.png
-          sips -z 32 32     assets/icon.png --out assets/icon.iconset/icon_16x16@2x.png
-          sips -z 32 32     assets/icon.png --out assets/icon.iconset/icon_32x32.png
-          sips -z 64 64     assets/icon.png --out assets/icon.iconset/icon_32x32@2x.png
-          sips -z 128 128   assets/icon.png --out assets/icon.iconset/icon_128x128.png
-          sips -z 256 256   assets/icon.png --out assets/icon.iconset/icon_128x128@2x.png
-          sips -z 256 256   assets/icon.png --out assets/icon.iconset/icon_256x256.png
-          sips -z 512 512   assets/icon.png --out assets/icon.iconset/icon_256x256@2x.png
-          sips -z 512 512   assets/icon.png --out assets/icon.iconset/icon_512x512.png
-          sips -z 1024 1024 assets/icon.png --out assets/icon.iconset/icon_512x512@2x.png
+          for size in 16 32 128 256 512; do
+            retina=$((size * 2))
+            sips -z $size $size assets/icon.png --out "assets/icon.iconset/icon_${size}x${size}.png"
+            sips -z $retina $retina assets/icon.png --out "assets/icon.iconset/icon_${size}x${size}@2x.png"
+          done
           iconutil -c icns assets/icon.iconset -o assets/icon.icns
 
       - name: Install dependencies
@@ -80,30 +181,26 @@ jobs:
         run: |
           codesign --force --deep --sign - out/tmax-darwin-${{ matrix.arch }}/tmax.app
 
-      # Rename Windows Squirrel artifacts to include architecture
-      - name: Rename Windows installer and Squirrel artifacts
+      - name: Rename Windows Squirrel artifacts
         if: matrix.platform == 'win32'
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
           SQDIR="out/make/squirrel.windows/${{ matrix.arch }}"
+          ARCH="${{ matrix.arch }}"
 
-          # Rename Setup.exe to include arch
+          # Rename Setup.exe and nupkg to include architecture
           for f in "$SQDIR"/*.exe; do
-            mv "$f" "$SQDIR/tmax-${VERSION}-${{ matrix.arch }}-Setup.exe"
+            mv "$f" "$SQDIR/tmax-${VERSION}-${ARCH}-Setup.exe"
           done
-
-          # Rename nupkg to include arch (e.g. tmax-1.4.8-x64-full.nupkg)
           for f in "$SQDIR"/*.nupkg; do
-            base=$(basename "$f")
-            newname=$(echo "$base" | sed "s/-full\.nupkg/-${{ matrix.arch }}-full.nupkg/")
-            mv "$f" "$SQDIR/$newname"
+            mv "$f" "$SQDIR/$(basename "$f" | sed "s/-full/-${ARCH}-full/")"
           done
 
-          # Rewrite RELEASES file entries to match renamed nupkg, then rename it
+          # Update RELEASES file entries to match renamed nupkg
           if [ -f "$SQDIR/RELEASES" ]; then
-            sed -i "s/-full\.nupkg/-${{ matrix.arch }}-full.nupkg/g" "$SQDIR/RELEASES"
-            mv "$SQDIR/RELEASES" "$SQDIR/RELEASES-${{ matrix.arch }}"
+            sed -i "s/-full\.nupkg/-${ARCH}-full.nupkg/g" "$SQDIR/RELEASES"
+            mv "$SQDIR/RELEASES" "$SQDIR/RELEASES-${ARCH}"
           fi
 
       # Create portable ZIP for Windows
@@ -129,9 +226,9 @@ jobs:
           if-no-files-found: warn
 
   release:
-    needs: build
+    needs: [prepare-release, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'workflow_dispatch'
 
     permissions:
       contents: write
@@ -145,22 +242,19 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
 
-      # Rename DMG files to include architecture
       - name: Rename DMG files to include architecture
         run: |
           for dir in artifacts/tmax-darwin-*/; do
-            arch=$(basename "$dir" | sed 's/tmax-darwin-//')
-            for dmg in "$dir"out/make/**/*.dmg; do
-              if [ -f "$dmg" ]; then
-                newname=$(dirname "$dmg")/tmax-darwin-${arch}.dmg
-                mv "$dmg" "$newname"
-              fi
-            done
+            arch="${dir##*-}" && arch="${arch%/}"
+            find "$dir" -name '*.dmg' -exec mv {} "$(dirname {})/../tmax-darwin-${arch}.dmg" \; 2>/dev/null || true
           done
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare-release.outputs.tag }}
+          name: ${{ needs.prepare-release.outputs.tag }}
+          body: ${{ needs.prepare-release.outputs.changelog_section }}
           files: |
             artifacts/**/*.exe
             artifacts/**/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,13 @@ on:
           - minor
           - major
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   prepare-release:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -102,14 +106,13 @@ jobs:
             echo "CHANGELOG_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Commit and tag
+      - name: Commit release bump
         id: push
         run: |
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore(release): v${{ steps.version.outputs.version }} [skip ci]"
           git pull --rebase origin main
-          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
-          git push origin main --follow-tags
+          git push origin main
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   build:
@@ -228,7 +231,7 @@ jobs:
   release:
     needs: [prepare-release, build]
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && needs.build.result == 'success'
 
     permissions:
       contents: write
@@ -246,7 +249,9 @@ jobs:
         run: |
           for dir in artifacts/tmax-darwin-*/; do
             arch="${dir##*-}" && arch="${arch%/}"
-            find "$dir" -name '*.dmg' -exec mv {} "$(dirname {})/../tmax-darwin-${arch}.dmg" \; 2>/dev/null || true
+            find "$dir" -name '*.dmg' | while read -r dmg; do
+              mv "$dmg" "$(dirname "$dmg")/../tmax-darwin-${arch}.dmg"
+            done
           done
 
       - name: Create Release
@@ -255,6 +260,7 @@ jobs:
           tag_name: ${{ needs.prepare-release.outputs.tag }}
           name: ${{ needs.prepare-release.outputs.tag }}
           body: ${{ needs.prepare-release.outputs.changelog_section }}
+          target_commitish: ${{ needs.prepare-release.outputs.sha }}
           files: |
             artifacts/**/*.exe
             artifacts/**/*.zip
@@ -268,3 +274,27 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rollback-on-failure:
+    needs: [prepare-release, build]
+    runs-on: ubuntu-latest
+    if: always() && github.event_name == 'workflow_dispatch' && needs.prepare-release.result == 'success' && needs.build.result != 'success'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Revert release bump commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git revert --no-edit ${{ needs.prepare-release.outputs.sha }}; then
+            echo "::error::Could not auto-revert release commit ${{ needs.prepare-release.outputs.sha }}. Please revert manually."
+            exit 1
+          fi
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -203,6 +203,24 @@ Output per platform:
 - **Linux**: `out/make/deb/x64/*.deb` and `out/make/rpm/x64/*.rpm`
 - **All**: portable `.zip`
 
+### Releasing
+
+Releases are created via **GitHub Actions workflow dispatch**:
+
+1. Go to **Actions → Build and Release → Run workflow**
+2. Select **bump type** (`patch`, `minor`, or `major`)
+3. Click **Run workflow**
+
+The CI will automatically:
+- Bump the version in `package.json`
+- Generate a changelog section from commit messages (with author attribution)
+- Prepend it to `CHANGELOG.md`
+- Commit, tag, and push
+- Build for all platforms (Windows x64/arm64, macOS x64/arm64, Linux x64)
+- Create a GitHub Release with the changelog and all artifacts
+
+> **Note:** Author usernames in the changelog link correctly when the committer's email is [added to their GitHub account](https://github.com/settings/emails). Otherwise, the plain name from the git commit is used.
+
 ## Architecture
 
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -411,7 +411,8 @@
 </div>
 
 <div class="changelog" id="changelog">
-  <div class="changelog-content" id="changelog-content">Loading release notes...</div>
+  <h2>Changelog</h2>
+  <div class="changelog-content" id="changelog-content">Loading changelog...</div>
 </div>
 
 <div class="features">
@@ -653,12 +654,22 @@ async function loadRelease() {
     src.innerHTML = '<span class="os-icon">&#128736;</span>Build from source';
     grid.appendChild(src);
 
-    // Render release notes
+    // Render full changelog from CHANGELOG.md (falls back to release body)
     const changelogEl = document.getElementById('changelog-content');
-    if (data.body) {
-      changelogEl.innerHTML = renderMarkdown(data.body);
-    } else {
-      changelogEl.innerHTML = `<p>See <a href="${data.html_url}">release notes on GitHub</a></p>`;
+    try {
+      const clRes = await fetch(`https://raw.githubusercontent.com/${REPO}/main/CHANGELOG.md`);
+      if (clRes.ok) {
+        const clText = await clRes.text();
+        changelogEl.innerHTML = renderMarkdown(clText.replace(/^# Changelog\s*\n/, ''));
+      } else {
+        throw new Error('not found');
+      }
+    } catch {
+      if (data.body) {
+        changelogEl.innerHTML = renderMarkdown(data.body);
+      } else {
+        changelogEl.innerHTML = `<p>See <a href="${data.html_url}">release notes on GitHub</a></p>`;
+      }
     }
 
     // Update version badge
@@ -676,7 +687,7 @@ async function loadRelease() {
     btn.href = `https://github.com/${REPO}/releases/latest`;
     document.getElementById('os-name').textContent = 'your platform';
     document.getElementById('os-detail').textContent = 'View releases on GitHub';
-    document.getElementById('changelog-content').innerHTML = '<p>Could not load release notes.</p>';
+    document.getElementById('changelog-content').innerHTML = '<p>Could not load changelog.</p>';
   }
 }
 
@@ -690,7 +701,7 @@ function renderMarkdown(md) {
     .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
     // Bare URLs (not already inside an href)
     .replace(/(^|[^"'>])(https?:\/\/[^\s<]+)/g, '$1<a href="$2" target="_blank" rel="noopener noreferrer">$2</a>')
-    .replace(/^- (.+)$/gm, '<li>$1</li>')
+    .replace(/^[*-] (.+)$/gm, '<li>$1</li>')
     .replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>')
     // Skip `\n\n -> <br><br>` — block elements (h2, h3, ul) already have
     // their own spacing. Inserting extra <br><br> between them creates a

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, globalShortcut, ipcMain, Menu, nativeTheme, powerMonitor, session, shell } from 'electron';
+import { app, BrowserWindow, globalShortcut, ipcMain, Menu, nativeTheme, net, powerMonitor, session, shell } from 'electron';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -592,6 +592,15 @@ function registerIpcHandlers(): void {
 
   ipcMain.on(IPC.VERSION_RESTART_AND_UPDATE, () => {
     versionChecker?.restartAndUpdate();
+  });
+
+  ipcMain.handle(IPC.VERSION_GET_CHANGELOG, async () => {
+    try {
+      const res = await net.fetch('https://raw.githubusercontent.com/InbarR/tmax/main/CHANGELOG.md');
+      return res.ok ? await res.text() : '';
+    } catch {
+      return '';
+    }
   });
 
   // ── Transparency IPC handlers ──────────────────────────────────────

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -293,6 +293,10 @@ const terminalAPI: TerminalAPI = {
     ipcRenderer.send(IPC.VERSION_RESTART_AND_UPDATE);
   },
 
+  getChangelog(): Promise<string> {
+    return ipcRenderer.invoke(IPC.VERSION_GET_CHANGELOG);
+  },
+
   getPtyDiag(id: string) {
     return ipcRenderer.invoke(IPC.PTY_GET_DIAG, id);
   },

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -32,10 +32,14 @@ function renderMarkdown(md: string): string {
     .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
     // Bare URLs
     .replace(/(^|[^"'])(https?:\/\/[^\s<]+)/g, '$1<a href="$2" target="_blank" rel="noopener noreferrer">$2</a>')
-    // Bullet lists
-    .replace(/^\* (.+)$/gm, '<li>$1</li>')
+    // Bullet lists (both * and -)
+    .replace(/^[*-] (.+)$/gm, '<li>$1</li>')
     .replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>')
-    // Line breaks
+    // Collapse multiple blank lines
+    .replace(/\n{3,}/g, '\n\n')
+    // Strip newlines adjacent to block elements (prevent extra <br/>)
+    .replace(/\n*(<\/?(?:h[1-6]|ul|li|p)>)\n*/g, '$1')
+    // Remaining line breaks
     .replace(/\n/g, '<br/>');
 }
 
@@ -73,6 +77,33 @@ const UpdateModal: React.FC<{ info: UpdateInfoState; appVersion: string; onClose
   );
 };
 
+const ChangelogModal: React.FC<{ content: string; loading: boolean; onClose: () => void }> = ({ content, loading, onClose }) => {
+  return (
+    <div className="update-modal-overlay" onClick={onClose}>
+      <div className="changelog-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="update-modal-header">
+          <h2>Changelog</h2>
+          <button className="update-modal-close" onClick={onClose}>&times;</button>
+        </div>
+        <div className="changelog-modal-content">
+          {loading ? (
+            <p style={{ textAlign: 'center', padding: '2rem' }}>Loading changelog...</p>
+          ) : content ? (
+            <div dangerouslySetInnerHTML={{ __html: renderMarkdown(
+              content.replace(/^# Changelog\s*\n/, '')
+            ) }} />
+          ) : (
+            <p>Could not load changelog.</p>
+          )}
+        </div>
+        <div className="update-modal-actions">
+          <button className="update-modal-btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const StatusBar: React.FC = () => {
   const [appVersion, setAppVersion] = useState<string>('');
   const [updateInfo, setUpdateInfo] = useState<UpdateInfoState | null>(null);
@@ -80,6 +111,9 @@ const StatusBar: React.FC = () => {
   const [shownVersion, setShownVersion] = useState<string>('');
   const [showReportModal, setShowReportModal] = useState(false);
   const [showZoomDialog, setShowZoomDialog] = useState(false);
+  const [showChangelog, setShowChangelog] = useState(false);
+  const [changelogContent, setChangelogContent] = useState('');
+  const [changelogLoading, setChangelogLoading] = useState(false);
 
   const submitReport = () => {
     const issueBody = `**Version:** ${appVersion}\n**Platform:** ${navigator.platform}\n\n**Description:**\n\n\n**Steps to reproduce:**\n1. \n\n**Expected behavior:**\n\n**Actual behavior:**\n`;
@@ -87,6 +121,18 @@ const StatusBar: React.FC = () => {
     window.terminalAPI.clipboardWrite(issueBody);
     window.open(url, '_blank');
     setShowReportModal(false);
+  };
+
+  const openChangelog = async () => {
+    setShowChangelog(true);
+    setChangelogLoading(true);
+    try {
+      const text = await window.terminalAPI.getChangelog();
+      setChangelogContent(text);
+    } catch {
+      setChangelogContent('');
+    }
+    setChangelogLoading(false);
   };
 
   useEffect(() => {
@@ -239,7 +285,7 @@ const StatusBar: React.FC = () => {
               v{appVersion} &rarr; v{updateInfo.latest}
             </span>
           ) : (
-            <span className="status-dim">v{appVersion}</span>
+            <span className="status-dim" style={{ cursor: 'pointer' }} onClick={openChangelog} data-tooltip="View changelog">v{appVersion}</span>
           )}
           <button
             className="status-mode-btn"
@@ -266,6 +312,9 @@ const StatusBar: React.FC = () => {
       </div>
       {showUpdateModal && updateInfo && (
         <UpdateModal info={updateInfo} appVersion={appVersion} onClose={() => setShowUpdateModal(false)} />
+      )}
+      {showChangelog && (
+        <ChangelogModal content={changelogContent} loading={changelogLoading} onClose={() => setShowChangelog(false)} />
       )}
       {showZoomDialog && (
         <InputDialog

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1603,6 +1603,60 @@ html.transparency-active .input-dialog {
   background: #5dd866;
 }
 
+/* ── Changelog Modal ────────────────────────────────────── */
+.changelog-modal {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  max-width: 600px;
+  width: 90vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.changelog-modal-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 24px 16px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+.changelog-modal-content h3 {
+  margin: 20px 0 8px;
+  font-size: 15px;
+  color: var(--focus-border);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
+}
+
+.changelog-modal-content h4 {
+  margin: 14px 0 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.changelog-modal-content ul {
+  margin: 6px 0;
+  padding-left: 20px;
+}
+
+.changelog-modal-content li {
+  margin: 2px 0;
+}
+
+.changelog-modal-content a {
+  color: var(--focus-border);
+  text-decoration: none;
+}
+
+.changelog-modal-content a:hover {
+  text-decoration: underline;
+}
+
 .status-cwd {
   color: var(--text-secondary);
   cursor: pointer;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -38,6 +38,7 @@ export const IPC = {
   VERSION_CHECK_NOW: 'version:checkNow',
   VERSION_GET_APP_VERSION: 'version:getAppVersion',
   VERSION_RESTART_AND_UPDATE: 'version:restartAndUpdate',
+  VERSION_GET_CHANGELOG: 'version:getChangelog',
   CLIPBOARD_SAVE_IMAGE: 'clipboard:saveImage',
   PTY_GET_DIAG: 'pty:getDiag',
   DIAG_LOG: 'diag:log',


### PR DESCRIPTION
Releases were basically empty — the body just had a compare link saying "Full Changelog" with no actual content. The website showed the same thing, and clicking the version in the app just opened GitHub.

This replaces the old tag-push release strategy with a **workflow_dispatch** flow. Instead of pushing a tag manually, you go to Actions, pick a bump type (patch/minor/major), and run the workflow. The CI handles everything — version bump, changelog generation, commit, tag, build, and release creation.

[Demo release on the fork (v1.5.10)](https://github.com/dorlugasigal/tmax/releases/tag/v1.5.10)

---

### Release workflow

You trigger a release from the Actions tab — pick patch, minor, or major and hit run. Three jobs handle the rest: prepare-release (bump + changelog + tag), build (all 5 platforms), and release (upload artifacts + create GitHub release).

<img width="541" alt="workflow dispatch UI" src="https://github.com/user-attachments/assets/13040410-1803-4bde-a4fd-16e7b7acbbd9" />
<img width="1829" alt="3-job pipeline" src="https://github.com/user-attachments/assets/362f41d1-a6b3-4b7b-98bb-0f032b5cddd2" />

[Example run on the fork](https://github.com/dorlugasigal/tmax/actions/runs/24835207838)

---

### Auto-generated release notes with author attribution

The CI generates a real changelog from commits using the GitHub API to resolve author usernames so they link properly. The example below is noisy because the fork has all the test commits — in this repo it'd be much cleaner, especially if we also enforce squash merges on PRs.

<img width="1753" alt="release notes" src="https://github.com/user-attachments/assets/d2d4246e-94d6-4ebb-a98f-d082b155727f" />

> Author attribution only links to GitHub profiles if the committer's email is added to their GitHub account. Otherwise it falls back to the plain git name.

---

### Website — full changelog

The website now fetches the full `CHANGELOG.md` instead of just the latest release link.

<img width="1388" alt="website changelog" src="https://github.com/user-attachments/assets/ef6ed566-f85c-4958-92fb-adfddb855ab9" />

---

### In-app changelog modal

Clicking the version in the status bar opens a scrollable changelog modal. Fetched through main process IPC to bypass CSP.

<img width="1477" alt="in-app changelog modal" src="https://github.com/user-attachments/assets/bddaed51-f289-425f-b5ad-d97d9d8cbc0b" />

---

### Other changes

- Improved `renderMarkdown` (dash bullet support, collapsed blank lines, cleaner spacing)
- Simplified macOS icon generation and Windows rename scripts
- Added release workflow docs to README