### PR TITLE
fix: preserve terminal buffer content across float/dock moves and grid rebuilds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-serialize": "^0.14.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
         "chokidar": "^3.6.0",
@@ -3087,6 +3088,12 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
       "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "chokidar": "^3.6.0",

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -2,8 +2,10 @@ import React, { useEffect, useRef, useCallback, useState, useReducer } from 'rea
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
+import { SerializeAddon } from '@xterm/addon-serialize';
 import { useTerminalStore } from '../state/terminal-store';
 import { registerTerminal, unregisterTerminal } from '../terminal-registry';
+import { saveTerminalBuffer, popTerminalBuffer } from '../terminal-buffer-cache';
 import { isMac } from '../utils/platform';
 import { runJumpToPromptSearch } from '../utils/jump-to-prompt';
 import type { AppConfig } from '../state/types';
@@ -194,6 +196,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
+  const serializeAddonRef = useRef<SerializeAddon | null>(null);
   const [showSearch, setShowSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResult, setSearchResult] = useState<{ resultIndex: number; resultCount: number } | null>(null);
@@ -300,9 +303,11 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
 
     const fitAddon = new FitAddon();
     const searchAddon = new SearchAddon();
+    const serializeAddon = new SerializeAddon();
 
     term.loadAddon(fitAddon);
     term.loadAddon(searchAddon);
+    term.loadAddon(serializeAddon);
 
     // Custom multi-line URL link provider (#62): xterm's built-in WebLinksAddon
     // stops detecting wrapped URLs past a certain row count, so very long links
@@ -578,6 +583,18 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
 
     terminalRef.current = term;
     fitAddonRef.current = fitAddon;
+    serializeAddonRef.current = serializeAddon;
+
+    // Restore buffer from a previous mount (e.g. after float↔dock move or
+    // grid rebuild). Write the serialized content before fitting so the
+    // buffer is populated at its original dimensions first.
+    const savedBuffer = popTerminalBuffer(terminalId);
+    if (savedBuffer) {
+      try {
+        term.resize(savedBuffer.cols, savedBuffer.rows);
+      } catch { /* container may constrain size */ }
+      term.write(savedBuffer.serialized);
+    }
 
     // Initial fit
     requestAnimationFrame(() => {
@@ -972,11 +989,24 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId }) => {
       wheelRecoveryEl?.removeEventListener('wheel', wheelRecoveryHandler);
       wheelRecoveryEl?.removeEventListener('dblclick', manualSyncHandler);
       titleDisposable.dispose();
+      // Flush any pending PTY data so serialize captures the latest content
+      if (pendingData) {
+        term.write(pendingData);
+        pendingData = '';
+      }
+      // Save buffer before dispose so a remount can restore it
+      try {
+        const serialized = serializeAddon.serialize();
+        saveTerminalBuffer(terminalId, serialized, term.cols, term.rows);
+      } catch (e) {
+        console.warn('[tmax] Failed to serialize terminal buffer:', terminalId, e);
+      }
       unregisterTerminal(terminalId);
       term.dispose();
       terminalRef.current = null;
       fitAddonRef.current = null;
       searchAddonRef.current = null;
+      serializeAddonRef.current = null;
     };
   }, [terminalId, handleFocus]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/renderer/terminal-buffer-cache.ts
+++ b/src/renderer/terminal-buffer-cache.ts
@@ -1,0 +1,51 @@
+/**
+ * Cache for xterm terminal buffer content across React unmount/remount cycles.
+ *
+ * When a TerminalPanel unmounts (e.g. float↔dock move, grid rebuild), the
+ * xterm Terminal is disposed and all buffer content is lost. This cache stores
+ * the serialized buffer so the new TerminalPanel instance can restore it.
+ *
+ * Safety measures:
+ * - Entries auto-expire after EXPIRY_MS (the remount should happen within one
+ *   React render cycle, so anything older is an orphan from a close/shutdown).
+ * - Serialized content is capped at MAX_SERIALIZED_BYTES to avoid memory bloat
+ *   from terminals with very large scrollback.
+ */
+
+const DEFAULT_EXPIRY_MS = 10_000;
+const MAX_SERIALIZED_BYTES = 2 * 1024 * 1024; // 2 MB
+
+let expiryMs = DEFAULT_EXPIRY_MS;
+
+/** Override the TTL for buffer cache entries (milliseconds). */
+export function setBufferCacheExpiry(ms: number): void {
+  expiryMs = ms;
+}
+
+interface BufferSnapshot {
+  serialized: string;
+  cols: number;
+  rows: number;
+  savedAt: number;
+}
+
+const cache = new Map<string, BufferSnapshot>();
+
+export function saveTerminalBuffer(id: string, serialized: string, cols: number, rows: number): void {
+  if (serialized.length > MAX_SERIALIZED_BYTES) {
+    // Too large — skip rather than hog memory
+    return;
+  }
+  cache.set(id, { serialized, cols, rows, savedAt: Date.now() });
+
+  setTimeout(() => { cache.delete(id); }, expiryMs);
+}
+
+export function popTerminalBuffer(id: string): BufferSnapshot | undefined {
+  const entry = cache.get(id);
+  if (!entry) return undefined;
+  cache.delete(id);
+  // Discard stale entries (shouldn't happen with setTimeout, but belt & suspenders)
+  if (Date.now() - entry.savedAt > expiryMs) return undefined;
+  return entry;
+}

--- a/src/renderer/terminal-buffer-cache.ts
+++ b/src/renderer/terminal-buffer-cache.ts
@@ -30,21 +30,37 @@ interface BufferSnapshot {
 }
 
 const cache = new Map<string, BufferSnapshot>();
+// Per-id expiry timers. Tracked separately so a re-save of the same id can
+// cancel the previous timer - otherwise the older timer would fire and
+// silently delete the fresher snapshot before the next mount can read it.
+const expiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function clearExpiryTimer(id: string): void {
+  const t = expiryTimers.get(id);
+  if (t) {
+    clearTimeout(t);
+    expiryTimers.delete(id);
+  }
+}
 
 export function saveTerminalBuffer(id: string, serialized: string, cols: number, rows: number): void {
   if (serialized.length > MAX_SERIALIZED_BYTES) {
     // Too large — skip rather than hog memory
     return;
   }
+  clearExpiryTimer(id);
   cache.set(id, { serialized, cols, rows, savedAt: Date.now() });
-
-  setTimeout(() => { cache.delete(id); }, expiryMs);
+  expiryTimers.set(id, setTimeout(() => {
+    cache.delete(id);
+    expiryTimers.delete(id);
+  }, expiryMs));
 }
 
 export function popTerminalBuffer(id: string): BufferSnapshot | undefined {
   const entry = cache.get(id);
   if (!entry) return undefined;
   cache.delete(id);
+  clearExpiryTimer(id);
   // Discard stale entries (shouldn't happen with setTimeout, but belt & suspenders)
   if (Date.now() - entry.savedAt > expiryMs) return undefined;
   return entry;

--- a/tests/e2e/float-buffer-preserved.spec.ts
+++ b/tests/e2e/float-buffer-preserved.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, Page } from '@playwright/test';
+import { launchTmax, getStoreState } from './fixtures/launch';
+
+// Regression for PR 76 / "moving a pane between tiled and floating modes
+// blanks the content". TerminalPanel unmounts when a pane changes mode, and
+// xterm's Terminal.dispose() drops the buffer; the fix snapshots the buffer
+// to an in-memory cache via @xterm/addon-serialize and restores it on the
+// remount that follows the mode change.
+//
+// This test writes a unique sentinel directly into the xterm buffer, moves
+// the pane to floating, asserts the sentinel survived, then moves it back to
+// tiled and asserts it still survived.
+
+const SENTINEL = `buffer-preserved-needle-${Math.random().toString(36).slice(2, 10)}`;
+
+async function bufferIncludes(window: Page, terminalId: string, needle: string): Promise<boolean> {
+  return window.evaluate(([id, n]) => {
+    const entry = (window as any).__getTerminalEntry(id);
+    if (!entry) return false;
+    const buf = entry.terminal.buffer.active;
+    for (let i = 0; i < buf.length; i++) {
+      const line = buf.getLine(i);
+      if (line && line.translateToString(true).includes(n)) return true;
+    }
+    return false;
+  }, [terminalId, needle] as const);
+}
+
+async function writeToBuffer(window: Page, terminalId: string, text: string): Promise<void> {
+  await window.evaluate(([id, t]) => {
+    return new Promise<void>((resolve) => {
+      const entry = (window as any).__getTerminalEntry(id);
+      if (!entry) { resolve(); return; }
+      entry.terminal.write(t, () => resolve());
+    });
+  }, [terminalId, text] as const);
+}
+
+test('terminal buffer content survives float ↔ dock mode changes', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForSelector('.terminal-panel', { timeout: 15_000 });
+    // Wait until the terminal is registered (TerminalPanel calls
+    // registerTerminal in its mount effect, after launchTmax's __terminalStore
+    // check has already passed).
+    await window.waitForFunction(() => {
+      const id = (window as any).__terminalStore.getState().focusedTerminalId;
+      return id && !!(window as any).__getTerminalEntry?.(id);
+    }, null, { timeout: 10_000 });
+
+    const state = await getStoreState(window);
+    const terminalId = state.terminalIds[0];
+    expect(terminalId).toBeTruthy();
+
+    // Drop a clearly identifiable line into the buffer, then sanity-check it
+    // shows up before any mode changes happen.
+    await writeToBuffer(window, terminalId, `\r\n${SENTINEL}\r\n`);
+    await window.waitForTimeout(150);
+    expect(await bufferIncludes(window, terminalId, SENTINEL)).toBe(true);
+
+    // tiled → floating. The store action updates layout, which unmounts the
+    // tiled panel and mounts a floating one for the same terminal id.
+    await window.evaluate((id: string) => {
+      (window as any).__terminalStore.getState().moveToFloat(id);
+    }, terminalId);
+    // Allow React to re-render and the new TerminalPanel to mount + restore.
+    await window.waitForFunction((id) => {
+      const t = (window as any).__terminalStore.getState().terminals.get(id);
+      return t?.mode === 'floating' && !!(window as any).__getTerminalEntry?.(id);
+    }, terminalId, { timeout: 5_000 });
+    await window.waitForTimeout(200);
+
+    expect(await bufferIncludes(window, terminalId, SENTINEL)).toBe(true);
+
+    // floating → tiled. Same dance in the other direction.
+    await window.evaluate((id: string) => {
+      (window as any).__terminalStore.getState().moveToTiling(id);
+    }, terminalId);
+    await window.waitForFunction((id) => {
+      const t = (window as any).__terminalStore.getState().terminals.get(id);
+      return t?.mode === 'tiled' && !!(window as any).__getTerminalEntry?.(id);
+    }, terminalId, { timeout: 5_000 });
+    await window.waitForTimeout(200);
+
+    expect(await bufferIncludes(window, terminalId, SENTINEL)).toBe(true);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Problem

When a terminal is moved between **tiled ↔ floating** mode (dock/undock), or when a new terminal is added in **grid mode**, the terminal content disappears — the pane goes blank. The PTY process is still alive, but the user loses all visible output and scrollback.

## Root Cause

`TerminalPanel` creates an xterm.js `Terminal` in a `useEffect`. When moved:

1. **Float ↔ Dock**: Terminal removed from tiling tree → added to `floatingPanels` (or vice versa) → React unmounts old `TerminalPanel`, mounts new one.
2. **Grid rebuild**: `buildGridTree()` creates new split node IDs → React keys change → existing components remount.

On unmount, `term.dispose()` destroys the entire xterm buffer.

## Fix

Use `@xterm/addon-serialize` to snapshot the buffer before `dispose()` and restore it on remount.

- **On cleanup**: flush pending PTY data, serialize buffer to cache
- **On init**: restore cached buffer at original dimensions, then fit to new container

### Cache safety

| Protection | Detail |
|---|---|
| **Auto-expiry** | Entries deleted after 10s (configurable). Remounts happen in ~1ms. |
| **Size cap** | Buffers > 2MB skipped to prevent memory bloat. |
| **Pop semantics** | Consumed on first read, preventing stale reuse. |

## Files Changed

- `package.json` — added `@xterm/addon-serialize`
- `src/renderer/terminal-buffer-cache.ts` — new module for buffer snapshots
- `src/renderer/components/TerminalPanel.tsx` — serialize on cleanup, restore on init