### PR TITLE
ui(sessions): swap Refresh and Group toolbar locations

### DIFF
--- a/src/renderer/components/CopilotPanel.tsx
+++ b/src/renderer/components/CopilotPanel.tsx
@@ -693,12 +693,12 @@ const CopilotPanel: React.FC = () => {
         <span>✨ AI Sessions</span>
         <div style={{ display: 'flex', gap: '4px', alignItems: 'center', position: 'relative' }}>
           <button
-            className={`ai-session-tab${groupByRepo ? ' active' : ''}`}
-            onClick={toggleGroupByRepo}
-            data-tooltip="Group sessions by repo"
-            style={{ fontSize: '10px', padding: '1px 6px' }}
+            className="dir-panel-close"
+            onClick={handleRefresh}
+            data-tooltip="Refresh"
+            aria-label="Refresh"
           >
-            Group
+            <span style={{ fontSize: '12px', lineHeight: 1 }}>⟲</span>
           </button>
           <button
             className="dir-panel-close"
@@ -725,10 +725,10 @@ const CopilotPanel: React.FC = () => {
               >
                 <button
                   className="context-menu-item"
-                  onClick={() => { handleRefresh(); setHeaderMenuOpen(false); }}
+                  onClick={() => { toggleGroupByRepo(); setHeaderMenuOpen(false); }}
                 >
-                  <span style={{ display: 'inline-block', width: 16 }}>⟲</span>
-                  Refresh
+                  <span style={{ display: 'inline-block', width: 16, color: groupByRepo ? 'var(--focus-border, #89b4fa)' : 'transparent' }}>✓</span>
+                  Group sessions by repo
                 </button>
                 <button
                   className="context-menu-item"

--- a/tests/e2e/issue-69-group-by-repo.spec.ts
+++ b/tests/e2e/issue-69-group-by-repo.spec.ts
@@ -18,28 +18,32 @@ test('Group toggle renders group headers and contiguous sessions per repo (#69)'
       return;
     }
 
-    // Group is on by default (#69) - click the Group button once to turn it
-    // OFF, so the test starts from a known headerless state, then click again
-    // to turn it back on and exercise the grouping path.
-    const findGroupBtn = async () => {
-      for (const b of await window.$$('.ai-session-tab')) {
-        const text = (await b.textContent() || '').trim();
-        if (text === 'Group') return b;
+    // Group is on by default (#69) - toggle the Group setting once to turn it
+    // OFF, so the test starts from a known headerless state, then toggle again
+    // to turn it back on and exercise the grouping path. The Group toggle now
+    // lives inside the header's "More actions" dropdown.
+    const toggleGroup = async () => {
+      const moreBtn = await window.$('.dir-panel-header [aria-label="More actions"]');
+      expect(moreBtn).not.toBeNull();
+      await moreBtn!.click();
+      await window.waitForTimeout(150);
+      for (const item of await window.$$('.context-menu-item')) {
+        const text = (await item.textContent() || '').trim();
+        if (text.includes('Group sessions by repo')) {
+          await item.click();
+          return;
+        }
       }
-      return null;
+      throw new Error('Group sessions by repo menu item not found');
     };
-    const groupOff = await findGroupBtn();
-    expect(groupOff).not.toBeNull();
-    await groupOff!.click();
+    await toggleGroup();
     await window.waitForTimeout(300);
 
     const headersBefore = await window.$$('.ai-session-group-header');
     expect(headersBefore.length).toBe(0);
 
-    // Click Group again - now we're testing the off→on transition.
-    const groupOn = await findGroupBtn();
-    expect(groupOn).not.toBeNull();
-    await groupOn!.click();
+    // Toggle Group again - now we're testing the off→on transition.
+    await toggleGroup();
     await window.waitForTimeout(400);
 
     // Now headers should appear. Groups auto-collapse on first toggle, so by
@@ -70,11 +74,8 @@ test('Group toggle renders group headers and contiguous sessions per repo (#69)'
     expect(expandedLayout[0]).toBe('H');
     expect(expandedLayout[1]).toBe('S');
 
-    // Clicking Group again should turn headers off
-    for (const b of await window.$$('.ai-session-tab')) {
-      const text = (await b.textContent() || '').trim();
-      if (text === 'Group') { await b.click(); break; }
-    }
+    // Toggling Group again should turn headers off
+    await toggleGroup();
     await window.waitForTimeout(300);
     const headersAfter = await window.$$('.ai-session-group-header');
     expect(headersAfter.length).toBe(0);


### PR DESCRIPTION
## Summary

In the AI Sessions panel header, swap the visible-toolbar slot used by **Group** with the dropdown slot used by **Refresh**.

- **Refresh** moves OUT of the More-actions dropdown into the visible toolbar as a small icon button (uses the existing ⟲ glyph; same `dir-panel-close` styling as the ⋯ and ✕ buttons next to it).
- **Group sessions by repo** moves INTO the More-actions dropdown, becoming the first item with a ✓ checkmark indicator (mirrors the existing `Show running only` pattern).

## Why

Refresh is the most frequently used action in this header — promote it to the toolbar so it's one click. Group-by-repo is a view-mode setting and naturally belongs alongside the other view settings already in the dropdown (Show running only, Expand/Collapse all groups). The conditional `Expand/Collapse all groups` item still appears under it whenever grouping is on.

## Test updates

- `tests/e2e/issue-69-group-by-repo.spec.ts` previously toggled Group via `.ai-session-tab` selector; updated to open the More-actions dropdown and click the `Group sessions by repo` menu item instead.

## Verification

- `npx tsc --noEmit` — clean for `CopilotPanel.tsx` and the updated test (no new errors introduced).