### PR TITLE
fix: OOM crash and startup freeze with 1000+ Copilot sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmax",
-  "version": "1.6.1",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmax",
-      "version": "1.6.1",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmax",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Powerful multi-terminal app with tiling, floating panels, and keyboard-driven workflow",
   "license": "MIT",
   "author": "tmax",

--- a/src/main/claude-code-session-monitor.ts
+++ b/src/main/claude-code-session-monitor.ts
@@ -25,6 +25,10 @@ export class ClaudeCodeSessionMonitor {
   private callbacks: ClaudeCodeMonitorCallbacks = {};
   private readonly basePath: string;
   private readonly wslDistro?: string;
+  /** Total eligible sessions found in the last scanSessions() call. */
+  lastTotalEligible = 0;
+  /** Cached candidate list from the last full stat scan, sorted by mtime desc. */
+  private cachedCandidates: { filePath: string; mtime: number }[] | null = null;
 
   constructor(options?: { basePath?: string; wslDistro?: string }) {
     this.basePath = options?.basePath ?? path.join(os.homedir(), '.claude', 'projects');
@@ -41,88 +45,100 @@ export class ClaudeCodeSessionMonitor {
 
   // ── Full scan ────────────────────────────────────────────────────────
 
-  scanSessions(): CopilotSessionSummary[] {
+  async scanSessions(limit = 50): Promise<CopilotSessionSummary[]> {
     const summaries: CopilotSessionSummary[] = [];
 
-    if (!fs.existsSync(this.basePath)) return summaries;
+    // Phase 1: build or reuse cached candidate list
+    // Uses sync stat - fast and only runs once (cached after).
+    if (!this.cachedCandidates) {
+      let projectDirs: fs.Dirent[];
+      try {
+        projectDirs = fs.readdirSync(this.basePath, { withFileTypes: true });
+      } catch {
+        return summaries;
+      }
 
-    let projectDirs: fs.Dirent[];
-    try {
-      projectDirs = fs.readdirSync(this.basePath, { withFileTypes: true });
-    } catch {
-      return summaries;
+      const maxAgeMs = 30 * 24 * 60 * 60 * 1000;
+      const cutoff = Date.now() - maxAgeMs;
+      const candidates: { filePath: string; mtime: number }[] = [];
+
+      for (const projEntry of projectDirs) {
+        if (!projEntry.isDirectory()) continue;
+        const projDir = path.join(this.basePath, projEntry.name);
+        let files: fs.Dirent[];
+        try { files = fs.readdirSync(projDir, { withFileTypes: true }); } catch { continue; }
+
+        for (const fileEntry of files) {
+          if (!fileEntry.isFile() || !UUID_RE.test(fileEntry.name)) continue;
+          const filePath = path.join(projDir, fileEntry.name);
+          let mtime = 0;
+          try { mtime = fs.statSync(filePath).mtimeMs; } catch { continue; }
+          if (mtime < cutoff) continue;
+          candidates.push({ filePath, mtime });
+        }
+      }
+
+      candidates.sort((a, b) => b.mtime - a.mtime);
+      this.cachedCandidates = candidates;
     }
 
+    const candidates = this.cachedCandidates;
+    this.lastTotalEligible = candidates.length;
+
+    // Phase 2: parse only the top N (skipping already-loaded sessions)
+    const top = candidates.slice(0, limit);
     const currentIds = new Set<string>();
-    // 30 days matches the app-wide `oldSessionDays` default used by the UI's
-    // stale-session detection and the "mark old" threshold. A tighter scan
-    // filter would hide sessions that `claude --resume` still lists.
-    const maxAgeMs = 30 * 24 * 60 * 60 * 1000;
-    const cutoff = Date.now() - maxAgeMs;
 
-    for (const projEntry of projectDirs) {
-      if (!projEntry.isDirectory()) continue;
+    let parseCount = 0;
+    for (const { filePath } of top) {
+      // Check if already loaded by file path
+      let existingId: string | null = null;
+      for (const [id, fp] of this.filePaths) {
+        if (fp === filePath) { existingId = id; break; }
+      }
 
-      const projDir = path.join(this.basePath, projEntry.name);
-
-      let files: fs.Dirent[];
-      try {
-        files = fs.readdirSync(projDir, { withFileTypes: true });
-      } catch {
+      if (existingId && this.sessions.has(existingId)) {
+        currentIds.add(existingId);
+        summaries.push(this.sessions.get(existingId)!);
         continue;
       }
 
-      for (const fileEntry of files) {
-        if (!fileEntry.isFile() || !UUID_RE.test(fileEntry.name)) continue;
+      const summary = this.loadSession(filePath);
 
-        const filePath = path.join(projDir, fileEntry.name);
+      if (summary) {
+        currentIds.add(summary.id);
+        this.sessions.set(summary.id, summary);
+        this.filePaths.set(summary.id, filePath);
+        summaries.push(summary);
+        this.callbacks.onSessionAdded?.(summary);
+      } else {
+        // Remove failed candidate so totalEligible stays accurate
+        this.cachedCandidates = candidates.filter(c => c.filePath !== filePath);
+        this.lastTotalEligible = this.cachedCandidates.length;
+      }
 
-        // Skip old sessions by file mtime
-        try {
-          const stat = fs.statSync(filePath);
-          if (stat.mtimeMs < cutoff) continue;
-        } catch {
-          continue;
-        }
-
-        const summary = this.loadSession(filePath);
-
-        if (summary) {
-          const old = this.sessions.get(summary.id);
-          currentIds.add(summary.id);
-          this.sessions.set(summary.id, summary);
-          this.filePaths.set(summary.id, filePath);
-          summaries.push(summary);
-
-          if (!old) {
-            this.callbacks.onSessionAdded?.(summary);
-          } else if (
-            old.status !== summary.status ||
-            old.messageCount !== summary.messageCount ||
-            old.toolCallCount !== summary.toolCallCount ||
-            old.summary !== summary.summary ||
-            old.latestPrompt !== summary.latestPrompt
-          ) {
-            // Chokidar's awaitWriteFinish can suppress 'change' events during
-            // long streaming turns (file never stable for 300ms), so this 10s
-            // fallback scan is often the only thing that ships updates.
-            this.callbacks.onSessionUpdated?.(summary);
-          }
-        }
+      // Yield to event loop every 10 parses so the UI stays responsive
+      if (++parseCount % 10 === 0) {
+        await new Promise<void>(resolve => setImmediate(resolve));
       }
     }
 
-    // Detect removed sessions
+    // Silently evict sessions outside the top N from memory and parser cache.
+    // Do NOT fire onSessionRemoved — these sessions still exist on disk.
     for (const [id, fp] of this.filePaths) {
       if (!currentIds.has(id)) {
         this.sessions.delete(id);
         this.filePaths.delete(id);
         clearClaudeCodeCache(fp);
-        this.callbacks.onSessionRemoved?.(id);
       }
     }
 
     return summaries;
+  }
+
+  /** Invalidate the cached candidate list so the next scanSessions() re-stats. */
+  invalidateCache(): void {
+    this.cachedCandidates = null;
   }
 
   // ── Single-session refresh ───────────────────────────────────────────
@@ -202,10 +218,28 @@ export class ClaudeCodeSessionMonitor {
   // ── Watcher callbacks ────────────────────────────────────────────────
 
   handleFileChanged(filePath: string): void {
+    // Promote the session to the front of the cached candidate list
+    if (this.cachedCandidates) {
+      const idx = this.cachedCandidates.findIndex(c => c.filePath === filePath);
+      if (idx > 0) {
+        const [entry] = this.cachedCandidates.splice(idx, 1);
+        entry.mtime = Date.now();
+        this.cachedCandidates.unshift(entry);
+      }
+    }
     this.refreshSession(filePath);
   }
 
   handleNewFile(filePath: string): void {
+    // Insert into cached candidates so "load more" sees the new session
+    if (this.cachedCandidates) {
+      let mtime = Date.now();
+      try { mtime = fs.statSync(filePath).mtimeMs; } catch { /* use now */ }
+      if (!this.cachedCandidates.some(c => c.filePath === filePath)) {
+        this.cachedCandidates.unshift({ filePath, mtime });
+        this.lastTotalEligible = this.cachedCandidates.length;
+      }
+    }
     const summary = this.loadSession(filePath);
     if (summary) {
       this.sessions.set(summary.id, summary);
@@ -224,11 +258,27 @@ export class ClaudeCodeSessionMonitor {
         break;
       }
     }
+    // Remove from cached candidates
+    if (this.cachedCandidates) {
+      this.cachedCandidates = this.cachedCandidates.filter(c => c.filePath !== filePath);
+      this.lastTotalEligible = this.cachedCandidates.length;
+    }
   }
 
   dispose(): void {
     this.sessions.clear();
     this.filePaths.clear();
+  }
+
+  /** Re-check only recently active sessions in memory (no directory scan). */
+  refreshLoadedSessions(): void {
+    for (const [, summary] of this.sessions) {
+      const fp = this.filePaths.get(summary.id);
+      // Only refresh sessions that might be in a stale "thinking" state.
+      if (fp && summary.status !== 'idle') {
+        this.refreshSession(fp);
+      }
+    }
   }
 
   // ── Internal ─────────────────────────────────────────────────────────

--- a/src/main/claude-code-session-watcher.ts
+++ b/src/main/claude-code-session-watcher.ts
@@ -67,6 +67,7 @@ export class ClaudeCodeSessionWatcher {
       this.callbacks.onFileRemoved(filePath);
     });
 
+    // Only refreshes already-loaded sessions (no directory scan), so safe at 10s.
     this.staleTimer = setInterval(() => {
       this.onStaleCheck?.();
     }, 10_000);

--- a/src/main/copilot-events-parser.ts
+++ b/src/main/copilot-events-parser.ts
@@ -1,7 +1,6 @@
 import * as fs from 'node:fs';
 import type {
   CopilotSessionStatus,
-  CopilotActivityEntry,
 } from '../shared/copilot-types';
 
 export interface ParsedSessionEvents {
@@ -9,33 +8,29 @@ export interface ParsedSessionEvents {
   messageCount: number;
   toolCallCount: number;
   lastActivityTime: number;
-  timeline: CopilotActivityEntry[];
   pendingToolCalls: number;
   totalTokens: number;
   latestPrompt: string;
   latestPromptTime: number;
 }
 
+/** Incremental state cache - stores aggregates, not raw events. */
 interface ParserCache {
   byteOffset: number;
-  events: EventRecord[];
-}
-
-interface EventRecord {
-  type: string;
-  timestamp: number;
-  data?: Record<string, unknown>;
+  status: CopilotSessionStatus;
+  messageCount: number;
+  toolCallCount: number;
+  lastActivityTime: number;
+  pendingToolCalls: number;
+  totalTokens: number;
+  latestPrompt: string;
+  latestPromptTime: number;
+  /** Last N prompts for search, capped to avoid unbounded growth. */
+  recentPrompts: string[];
 }
 
 const cache = new Map<string, ParserCache>();
-
-interface PromptsCacheEntry {
-  mtimeMs: number;
-  size: number;
-  limit: number;
-  prompts: string[];
-}
-const promptsCache = new Map<string, PromptsCacheEntry>();
+const MAX_CACHED_PROMPTS = 20;
 
 export function parseSessionEvents(eventsFilePath: string): ParsedSessionEvents | null {
   let fileHandle: number | undefined;
@@ -45,15 +40,14 @@ export function parseSessionEvents(eventsFilePath: string): ParsedSessionEvents 
 
     const cached = cache.get(eventsFilePath);
     const startOffset = cached?.byteOffset ?? 0;
-    const existingEvents = cached?.events ?? [];
 
-    if (startOffset >= fileSize && existingEvents.length > 0) {
-      return deriveState(existingEvents);
+    if (cached && startOffset >= fileSize) {
+      return cacheToResult(cached);
     }
 
     const bytesToRead = fileSize - startOffset;
-    if (bytesToRead <= 0 && existingEvents.length > 0) {
-      return deriveState(existingEvents);
+    if (bytesToRead <= 0 && cached) {
+      return cacheToResult(cached);
     }
 
     if (bytesToRead <= 0) {
@@ -73,20 +67,35 @@ export function parseSessionEvents(eventsFilePath: string): ParsedSessionEvents 
     const newText = buffer.slice(0, completeBytes).toString('utf-8');
     const lines = newText.split('\n').filter((l) => l.trim().length > 0);
 
-    const newEvents: EventRecord[] = [];
+    // Update running state incrementally — no raw events stored
+    const state: ParserCache = cached
+      ? { ...cached }
+      : {
+          byteOffset: 0,
+          status: 'idle',
+          messageCount: 0,
+          toolCallCount: 0,
+          lastActivityTime: 0,
+          pendingToolCalls: 0,
+          totalTokens: 0,
+          latestPrompt: '',
+          latestPromptTime: 0,
+          recentPrompts: [],
+        };
+
     for (const line of lines) {
       try {
-        const parsed = JSON.parse(line);
-        newEvents.push(normalizeEvent(parsed));
+        const raw = JSON.parse(line);
+        processEvent(raw, state);
       } catch {
         // skip malformed lines
       }
     }
 
-    const allEvents = [...existingEvents, ...newEvents];
-    cache.set(eventsFilePath, { byteOffset: startOffset + completeBytes, events: allEvents });
+    state.byteOffset = startOffset + completeBytes;
+    cache.set(eventsFilePath, state);
 
-    return deriveState(allEvents);
+    return cacheToResult(state);
   } catch {
     return null;
   } finally {
@@ -96,13 +105,94 @@ export function parseSessionEvents(eventsFilePath: string): ParsedSessionEvents 
   }
 }
 
-export function extractCopilotPrompts(eventsFilePath: string, limit = 20): string[] {
-  try {
-    const stat = fs.statSync(eventsFilePath);
-    const cached = promptsCache.get(eventsFilePath);
-    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size && cached.limit === limit) {
-      return cached.prompts;
+/** Process a single raw event into the running state. */
+function processEvent(raw: Record<string, unknown>, state: ParserCache): void {
+  const type = (raw.type as string) || 'unknown';
+  const timestamp = raw.timestamp
+    ? new Date(raw.timestamp as string).getTime()
+    : Date.now();
+  const data = raw.data as Record<string, unknown> | undefined;
+
+  if (timestamp > state.lastActivityTime) {
+    state.lastActivityTime = timestamp;
+  }
+
+  switch (type) {
+    case 'session.start':
+    case 'session.resume':
+      state.status = 'idle';
+      break;
+    case 'assistant.turn_start':
+      state.status = 'thinking';
+      break;
+    case 'assistant.turn_end':
+      state.status = 'idle';
+      break;
+    case 'user.message': {
+      state.messageCount++;
+      state.status = 'thinking';
+      const text = String(data?.content || data?.transformedContent || '').trim();
+      if (text) {
+        state.latestPrompt = text.slice(0, 120).replace(/\n/g, ' ');
+        state.latestPromptTime = timestamp;
+        state.recentPrompts.push(text.slice(0, 300));
+        if (state.recentPrompts.length > MAX_CACHED_PROMPTS) {
+          state.recentPrompts.shift();
+        }
+      }
+      break;
     }
+    case 'tool.execution_start':
+      state.toolCallCount++;
+      state.pendingToolCalls++;
+      state.status = 'executingTool';
+      break;
+    case 'tool.execution_complete':
+      if (state.pendingToolCalls > 0) state.pendingToolCalls--;
+      if (state.pendingToolCalls === 0) state.status = 'thinking';
+      break;
+    case 'confirmation_request':
+    case 'approval_request':
+      state.status = 'awaitingApproval';
+      break;
+    case 'confirmation_response':
+    case 'approval_response':
+      state.status = 'thinking';
+      break;
+    case 'input_request':
+    case 'user_input_request':
+      state.status = 'waitingForUser';
+      break;
+    case 'token_usage':
+      if (data) {
+        const tokens = (data.total_tokens as number) || (data.totalTokens as number) || 0;
+        if (tokens > 0) state.totalTokens = tokens;
+      }
+      break;
+  }
+}
+
+function cacheToResult(cached: ParserCache): ParsedSessionEvents {
+  return {
+    status: cached.status,
+    messageCount: cached.messageCount,
+    toolCallCount: cached.toolCallCount,
+    lastActivityTime: cached.lastActivityTime,
+    pendingToolCalls: cached.pendingToolCalls,
+    totalTokens: cached.totalTokens,
+    latestPrompt: cached.latestPrompt,
+    latestPromptTime: cached.latestPromptTime,
+  };
+}
+
+export function extractCopilotPrompts(eventsFilePath: string, limit = 20): string[] {
+  // Use cached prompts from the parser if available (avoids re-reading the file)
+  const cached = cache.get(eventsFilePath);
+  if (cached && cached.recentPrompts.length > 0) {
+    return cached.recentPrompts.slice(-limit);
+  }
+  // Fallback: read file (only for sessions not yet parsed)
+  try {
     const content = fs.readFileSync(eventsFilePath, 'utf-8');
     const prompts: string[] = [];
     for (const line of content.split('\n')) {
@@ -115,9 +205,7 @@ export function extractCopilotPrompts(eventsFilePath: string, limit = 20): strin
         }
       } catch { /* skip */ }
     }
-    const result = prompts.slice(-limit);
-    promptsCache.set(eventsFilePath, { mtimeMs: stat.mtimeMs, size: stat.size, limit, prompts: result });
-    return result;
+    return prompts.slice(-limit);
   } catch {
     return [];
   }
@@ -125,114 +213,4 @@ export function extractCopilotPrompts(eventsFilePath: string, limit = 20): strin
 
 export function clearParserCache(eventsFilePath: string): void {
   cache.delete(eventsFilePath);
-  promptsCache.delete(eventsFilePath);
-}
-
-function normalizeEvent(raw: Record<string, unknown>): EventRecord {
-  const type = (raw.type as string) || 'unknown';
-  const timestamp = raw.timestamp
-    ? new Date(raw.timestamp as string).getTime()
-    : Date.now();
-
-  return { type, timestamp, data: raw.data as Record<string, unknown> | undefined };
-}
-
-function deriveState(events: EventRecord[]): ParsedSessionEvents {
-  let status: CopilotSessionStatus = 'idle';
-  let messageCount = 0;
-  let toolCallCount = 0;
-  let lastActivityTime = 0;
-  let pendingToolCalls = 0;
-  let totalTokens = 0;
-  let latestPrompt = '';
-  let latestPromptTime = 0;
-
-  for (const event of events) {
-    if (event.timestamp > lastActivityTime) {
-      lastActivityTime = event.timestamp;
-    }
-
-    switch (event.type) {
-      // Session lifecycle
-      case 'session.start':
-      case 'session.resume':
-        status = 'idle';
-        break;
-
-      // Assistant turns
-      case 'assistant.turn_start':
-        status = 'thinking';
-        break;
-      case 'assistant.turn_end':
-        status = 'idle';
-        break;
-
-      // Messages
-      case 'user.message': {
-        messageCount++;
-        status = 'thinking';
-        const text = String(event.data?.content || event.data?.transformedContent || '').trim();
-        if (text) {
-          latestPrompt = text.slice(0, 120).replace(/\n/g, ' ');
-          latestPromptTime = event.timestamp;
-        }
-        break;
-      }
-      case 'assistant.message':
-        break;
-
-      // Tool execution
-      case 'tool.execution_start':
-        toolCallCount++;
-        pendingToolCalls++;
-        status = 'executingTool';
-        break;
-      case 'tool.execution_complete':
-        if (pendingToolCalls > 0) pendingToolCalls--;
-        if (pendingToolCalls === 0) status = 'thinking';
-        break;
-
-      // Confirmation / approval
-      case 'confirmation_request':
-      case 'approval_request':
-        status = 'awaitingApproval';
-        break;
-      case 'confirmation_response':
-      case 'approval_response':
-        status = 'thinking';
-        break;
-
-      // Input requests
-      case 'input_request':
-      case 'user_input_request':
-        status = 'waitingForUser';
-        break;
-
-      // Token usage
-      case 'token_usage':
-        if (event.data) {
-          const tokens = (event.data.total_tokens as number) || (event.data.totalTokens as number) || 0;
-          if (tokens > 0) totalTokens = tokens;
-        }
-        break;
-    }
-  }
-
-  const timeline: CopilotActivityEntry[] = events.slice(-50).map((e) => ({
-    type: e.type,
-    timestamp: e.timestamp,
-    data: e.data,
-  }));
-
-  return {
-    status,
-    messageCount,
-    toolCallCount,
-    lastActivityTime,
-    timeline,
-    pendingToolCalls,
-    totalTokens,
-    latestPrompt,
-    latestPromptTime,
-  };
 }

--- a/src/main/copilot-session-monitor.ts
+++ b/src/main/copilot-session-monitor.ts
@@ -19,6 +19,10 @@ export class CopilotSessionMonitor {
   private callbacks: CopilotMonitorCallbacks = {};
   private readonly basePath: string;
   private readonly wslDistro?: string;
+  /** Total eligible sessions found in the last scanSessions() call. */
+  lastTotalEligible = 0;
+  /** Cached candidate list from the last full stat scan, sorted by mtime desc. */
+  private cachedCandidates: { sessionId: string; sessionDir: string; mtime: number }[] | null = null;
 
   constructor(options?: { basePath?: string; wslDistro?: string }) {
     this.basePath = options?.basePath ?? path.join(os.homedir(), '.copilot', 'session-state');
@@ -33,84 +37,95 @@ export class CopilotSessionMonitor {
     return this.basePath;
   }
 
-  scanSessions(): CopilotSessionSummary[] {
+  async scanSessions(limit = 50): Promise<CopilotSessionSummary[]> {
     const summaries: CopilotSessionSummary[] = [];
 
-    if (!fs.existsSync(this.basePath)) {
-      return summaries;
-    }
-
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(this.basePath, { withFileTypes: true });
-    } catch {
-      return summaries;
-    }
-
-    const currentIds = new Set<string>();
-    // 30 days matches the app-wide `oldSessionDays` default used by the UI's
-    // stale-session detection and the "mark old" threshold. A tighter scan
-    // filter would hide sessions that `gh copilot --list` still reports.
-    const maxAgeMs = 30 * 24 * 60 * 60 * 1000;
-    const cutoff = Date.now() - maxAgeMs;
-
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-
-      const sessionId = entry.name;
-      const sessionDir = path.join(this.basePath, sessionId);
-
-      // Quick recency check via workspace.yaml mtime before full parse
-      const wsPath = path.join(sessionDir, 'workspace.yaml');
+    // Phase 1: build or reuse cached candidate list
+    // Uses sync stat - fast (~300ms) and only runs once (cached after).
+    if (!this.cachedCandidates) {
+      let entries: fs.Dirent[];
       try {
-        const stat = fs.statSync(wsPath);
-        if (stat.mtimeMs < cutoff) continue;
+        entries = fs.readdirSync(this.basePath, { withFileTypes: true });
       } catch {
-        // No workspace.yaml — check events.jsonl
-        const evPath = path.join(sessionDir, 'events.jsonl');
-        try {
-          const stat = fs.statSync(evPath);
-          if (stat.mtimeMs < cutoff) continue;
-        } catch {
-          continue;
-        }
+        return summaries;
       }
 
+      const maxAgeMs = 30 * 24 * 60 * 60 * 1000;
+      const cutoff = Date.now() - maxAgeMs;
+      const candidates: { sessionId: string; sessionDir: string; mtime: number }[] = [];
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const sessionId = entry.name;
+        const sessionDir = path.join(this.basePath, sessionId);
+        // Prefer events.jsonl mtime (activity file) over workspace.yaml
+        let mtime = 0;
+        try {
+          mtime = fs.statSync(path.join(sessionDir, 'events.jsonl')).mtimeMs;
+        } catch {
+          try { mtime = fs.statSync(path.join(sessionDir, 'workspace.yaml')).mtimeMs; } catch { continue; }
+        }
+        if (mtime < cutoff) continue;
+        candidates.push({ sessionId, sessionDir, mtime });
+      }
+
+      candidates.sort((a, b) => b.mtime - a.mtime);
+      this.cachedCandidates = candidates;
+    }
+
+    const candidates = this.cachedCandidates;
+    this.lastTotalEligible = candidates.length;
+
+    // Phase 2: parse only the top N (skipping already-loaded sessions)
+    const top = candidates.slice(0, limit);
+    const currentIds = new Set<string>();
+
+    let parseCount = 0;
+    for (const { sessionId, sessionDir } of top) {
       currentIds.add(sessionId);
+
+      // Skip re-parsing sessions already in memory
+      if (this.sessions.has(sessionId)) {
+        summaries.push(this.toSummary(this.sessions.get(sessionId)!));
+        continue;
+      }
 
       const session = this.loadSession(sessionId, sessionDir);
 
       if (session) {
-        const oldSession = this.sessions.get(sessionId);
         this.sessions.set(sessionId, session);
         const summary = this.toSummary(session);
         summaries.push(summary);
+        this.callbacks.onSessionAdded?.(summary);
+      } else {
+        // Remove failed candidate so totalEligible stays accurate
+        this.cachedCandidates = candidates.filter(c => c.sessionId !== sessionId);
+        this.lastTotalEligible = this.cachedCandidates.length;
+      }
 
-        if (!oldSession) {
-          this.callbacks.onSessionAdded?.(summary);
-        } else if (
-          oldSession.status !== session.status ||
-          oldSession.messageCount !== session.messageCount ||
-          oldSession.toolCallCount !== session.toolCallCount ||
-          oldSession.latestPrompt !== session.latestPrompt
-        ) {
-          // Mirror of refreshSession's diff-check so the 10s fallback scan
-          // actually notifies the renderer when chokidar misses a 'change'.
-          this.callbacks.onSessionUpdated?.(summary);
-        }
+      // Yield to event loop every 10 parses so the UI stays responsive
+      if (++parseCount % 10 === 0) {
+        await new Promise<void>(resolve => setImmediate(resolve));
       }
     }
 
-    // Detect removed sessions
+    // Silently evict sessions outside the top N from memory and parser cache.
+    // Do NOT fire onSessionRemoved — these sessions still exist on disk, they're
+    // just outside the current load window. onSessionRemoved is reserved for
+    // sessions truly deleted from disk (handled by handleSessionRemoved).
     for (const [id] of this.sessions) {
       if (!currentIds.has(id)) {
         this.sessions.delete(id);
         clearParserCache(path.join(this.basePath, id, 'events.jsonl'));
-        this.callbacks.onSessionRemoved?.(id);
       }
     }
 
     return summaries;
+  }
+
+  /** Invalidate the cached candidate list so the next scanSessions() re-stats. */
+  invalidateCache(): void {
+    this.cachedCandidates = null;
   }
 
   getSession(id: string): CopilotSession | null {
@@ -177,11 +192,33 @@ export class CopilotSessionMonitor {
   }
 
   handleEventsChanged(sessionId: string): void {
+    // Promote the session to the front of the cached candidate list
+    if (this.cachedCandidates) {
+      const idx = this.cachedCandidates.findIndex(c => c.sessionId === sessionId);
+      if (idx > 0) {
+        const [entry] = this.cachedCandidates.splice(idx, 1);
+        entry.mtime = Date.now();
+        this.cachedCandidates.unshift(entry);
+      }
+    }
     this.refreshSession(sessionId);
   }
 
   handleNewSession(sessionId: string): void {
     const sessionDir = path.join(this.basePath, sessionId);
+    // Insert into cached candidates so "load more" sees the new session
+    if (this.cachedCandidates) {
+      const wsPath = path.join(sessionDir, 'workspace.yaml');
+      let mtime = Date.now();
+      try { mtime = fs.statSync(wsPath).mtimeMs; } catch {
+        try { mtime = fs.statSync(path.join(sessionDir, 'events.jsonl')).mtimeMs; } catch { /* use now */ }
+      }
+      // Prepend (newest first) if not already present
+      if (!this.cachedCandidates.some(c => c.sessionId === sessionId)) {
+        this.cachedCandidates.unshift({ sessionId, sessionDir, mtime });
+        this.lastTotalEligible = this.cachedCandidates.length;
+      }
+    }
     const session = this.loadSession(sessionId, sessionDir);
     if (session) {
       this.sessions.set(sessionId, session);
@@ -195,10 +232,26 @@ export class CopilotSessionMonitor {
       clearParserCache(path.join(this.basePath, sessionId, 'events.jsonl'));
       this.callbacks.onSessionRemoved?.(sessionId);
     }
+    // Remove from cached candidates
+    if (this.cachedCandidates) {
+      this.cachedCandidates = this.cachedCandidates.filter(c => c.sessionId !== sessionId);
+      this.lastTotalEligible = this.cachedCandidates.length;
+    }
   }
 
   dispose(): void {
     this.sessions.clear();
+  }
+
+  /** Re-check only recently active sessions in memory (no directory scan). */
+  refreshLoadedSessions(): void {
+    for (const [id, session] of this.sessions) {
+      // Only refresh sessions that might be in a stale "thinking" state.
+      // Idle sessions with no recent activity don't need re-checking.
+      if (session.status !== 'idle') {
+        this.refreshSession(id);
+      }
+    }
   }
 
   private loadSession(id: string, sessionDir: string): CopilotSession | null {
@@ -223,7 +276,6 @@ export class CopilotSessionMonitor {
       messageCount: parsed?.messageCount ?? 0,
       toolCallCount: parsed?.toolCallCount ?? 0,
       lastActivityTime: parsed?.lastActivityTime ?? 0,
-      timeline: parsed?.timeline ?? [],
       pendingToolCalls: parsed?.pendingToolCalls ?? 0,
       totalTokens: parsed?.totalTokens ?? 0,
       latestPrompt: parsed?.latestPrompt || undefined,

--- a/src/main/copilot-session-watcher.ts
+++ b/src/main/copilot-session-watcher.ts
@@ -75,10 +75,11 @@ export class CopilotSessionWatcher {
       }
     });
 
-    // Status timer to detect stale "thinking" sessions
+    // Status timer to detect stale "thinking" sessions.
+    // Only refreshes already-loaded sessions (no directory scan), so safe at 10s.
     this.staleTimer = setInterval(() => {
       this.onStaleCheck?.();
-    }, 5000);
+    }, 10_000);
   }
 
   async stop(): Promise<void> {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -752,10 +752,11 @@ function registerIpcHandlers(): void {
   });
 
   // ── Copilot IPC handlers ────────────────────────────────────────────
-  ipcMain.handle(IPC.COPILOT_LIST_SESSIONS, () => {
-    const native = copilotMonitor?.scanSessions() ?? [];
-    const wsl = wslSessionManager?.scanCopilotSessions() ?? [];
-    return [...native, ...wsl];
+  ipcMain.handle(IPC.COPILOT_LIST_SESSIONS, async (_event, limit?: number) => {
+    const native = await copilotMonitor?.scanSessions(limit ?? 50) ?? [];
+    const wsl = await wslSessionManager?.scanCopilotSessions() ?? [];
+    const totalEligible = (copilotMonitor?.lastTotalEligible ?? 0) + wsl.length;
+    return { sessions: [...native, ...wsl], totalEligible };
   });
 
   ipcMain.handle(IPC.COPILOT_GET_SESSION, (_event, id: string) => {
@@ -786,11 +787,17 @@ function registerIpcHandlers(): void {
     return wslSessionManager?.getCopilotPrompts(id) ?? [];
   });
 
+  ipcMain.handle(IPC.AI_INVALIDATE_CACHES, () => {
+    copilotMonitor?.invalidateCache();
+    claudeCodeMonitor?.invalidateCache();
+  });
+
   // ── Claude Code IPC handlers ──────────────────────────────────────────
-  ipcMain.handle(IPC.CLAUDE_CODE_LIST_SESSIONS, () => {
-    const native = claudeCodeMonitor?.scanSessions() ?? [];
-    const wsl = wslSessionManager?.scanClaudeCodeSessions() ?? [];
-    return [...native, ...wsl];
+  ipcMain.handle(IPC.CLAUDE_CODE_LIST_SESSIONS, async (_event, limit?: number) => {
+    const native = await claudeCodeMonitor?.scanSessions(limit ?? 50) ?? [];
+    const wsl = await wslSessionManager?.scanClaudeCodeSessions() ?? [];
+    const totalEligible = (claudeCodeMonitor?.lastTotalEligible ?? 0) + wsl.length;
+    return { sessions: [...native, ...wsl], totalEligible };
   });
 
   ipcMain.handle(IPC.CLAUDE_CODE_GET_SESSION, (_event, id: string) => {
@@ -1105,8 +1112,8 @@ function setupCopilotMonitor(): void {
   });
 
   copilotWatcher.setStaleCheckCallback(() => {
-    // Re-scan all sessions periodically to catch stale states
-    copilotMonitor!.scanSessions();
+    // Only refresh already-loaded sessions — no full directory re-scan
+    copilotMonitor!.refreshLoadedSessions();
   });
 }
 
@@ -1143,7 +1150,7 @@ function setupClaudeCodeMonitor(): void {
   });
 
   claudeCodeWatcher.setStaleCheckCallback(() => {
-    claudeCodeMonitor!.scanSessions();
+    claudeCodeMonitor!.refreshLoadedSessions();
   });
 }
 

--- a/src/main/wsl-session-manager.ts
+++ b/src/main/wsl-session-manager.ts
@@ -55,7 +55,7 @@ export class WslSessionManager {
         onNewSession: (id) => copilotMonitor.handleNewSession(id),
         onSessionRemoved: (id) => copilotMonitor.handleSessionRemoved(id),
       });
-      copilotWatcher.setStaleCheckCallback(() => copilotMonitor.scanSessions());
+      copilotWatcher.setStaleCheckCallback(() => copilotMonitor.refreshLoadedSessions());
 
       const claudeMonitor = new ClaudeCodeSessionMonitor({
         basePath: distro.claudeBasePath,
@@ -72,7 +72,7 @@ export class WslSessionManager {
         onNewFile: (fp) => claudeMonitor.handleNewFile(fp),
         onFileRemoved: (fp) => claudeMonitor.handleFileRemoved(fp),
       });
-      claudeWatcher.setStaleCheckCallback(() => claudeMonitor.scanSessions());
+      claudeWatcher.setStaleCheckCallback(() => claudeMonitor.refreshLoadedSessions());
 
       this.pairs.push({
         distro: distro.name,
@@ -97,26 +97,26 @@ export class WslSessionManager {
     // (watchers use ignoreInitial: true, so won't detect pre-existing files)
     for (const pair of this.pairs) {
       try {
-        pair.copilotMonitor.scanSessions();
-        pair.claudeMonitor.scanSessions();
+        await pair.copilotMonitor.scanSessions();
+        await pair.claudeMonitor.scanSessions();
       } catch (err) {
         console.error(`WSL scan failed for distro ${pair.distro}:`, err);
       }
     }
   }
 
-  scanCopilotSessions(): CopilotSessionSummary[] {
+  async scanCopilotSessions(): Promise<CopilotSessionSummary[]> {
     const results: CopilotSessionSummary[] = [];
     for (const pair of this.pairs) {
-      results.push(...pair.copilotMonitor.scanSessions());
+      results.push(...await pair.copilotMonitor.scanSessions());
     }
     return results;
   }
 
-  scanClaudeCodeSessions(): CopilotSessionSummary[] {
+  async scanClaudeCodeSessions(): Promise<CopilotSessionSummary[]> {
     const results: CopilotSessionSummary[] = [];
     for (const pair of this.pairs) {
-      results.push(...pair.claudeMonitor.scanSessions());
+      results.push(...await pair.claudeMonitor.scanSessions());
     }
     return results;
   }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -205,8 +205,8 @@ const terminalAPI: TerminalAPI = {
   },
 
   // ── Copilot session APIs ──────────────────────────────────────────
-  listCopilotSessions() {
-    return ipcRenderer.invoke(IPC.COPILOT_LIST_SESSIONS);
+  listCopilotSessions(limit?: number) {
+    return ipcRenderer.invoke(IPC.COPILOT_LIST_SESSIONS, limit);
   },
 
   getCopilotSession(id: string) {
@@ -227,6 +227,10 @@ const terminalAPI: TerminalAPI = {
 
   getCopilotPrompts(id: string) {
     return ipcRenderer.invoke(IPC.COPILOT_GET_PROMPTS, id);
+  },
+
+  invalidateSessionCaches() {
+    return ipcRenderer.invoke(IPC.AI_INVALIDATE_CACHES);
   },
 
   onCopilotSessionUpdated(cb: (session: unknown) => void): () => void {
@@ -260,8 +264,8 @@ const terminalAPI: TerminalAPI = {
   },
 
   // ── Claude Code session APIs ───────────────────────────────────────
-  listClaudeCodeSessions() {
-    return ipcRenderer.invoke(IPC.CLAUDE_CODE_LIST_SESSIONS);
+  listClaudeCodeSessions(limit?: number) {
+    return ipcRenderer.invoke(IPC.CLAUDE_CODE_LIST_SESSIONS, limit);
   },
 
   getClaudeCodeSession(id: string) {

--- a/src/renderer/components/CopilotPanel.tsx
+++ b/src/renderer/components/CopilotPanel.tsx
@@ -141,6 +141,28 @@ const CopilotPanel: React.FC = () => {
     }
     return m;
   }, [terminals, tabGroups, defaultTabColor]);
+  const copilotSessionsTotal = useTerminalStore((s) => s.copilotSessionsTotal);
+  const claudeCodeSessionsTotal = useTerminalStore((s) => s.claudeCodeSessionsTotal);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [renderLimit, setRenderLimit] = useState(200);
+
+  const totalLoaded = copilotSessions.length + claudeCodeSessions.length;
+  const totalEligible = copilotSessionsTotal + claudeCodeSessionsTotal;
+  const hasMore = totalEligible > totalLoaded;
+
+  const handleLoadMore = async () => {
+    setLoadingMore(true);
+    try { await useTerminalStore.getState().loadMoreSessions(100); } finally { setLoadingMore(false); }
+  };
+  const handleLoadAll = async () => {
+    if (totalEligible > 1000) {
+      const ok = confirm(`Loading all ${totalEligible.toLocaleString()} sessions may use significant memory. Continue?`);
+      if (!ok) return;
+    }
+    setLoadingMore(true);
+    try { await useTerminalStore.getState().loadAllSessions(); } finally { setLoadingMore(false); }
+  };
+
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(new Set());
@@ -528,7 +550,8 @@ const CopilotPanel: React.FC = () => {
     setCtxMenu(null);
   }, [summaryOverrides]);
 
-  const handleRefresh = useCallback(() => {
+  const handleRefresh = useCallback(async () => {
+    await (window.terminalAPI as any).invalidateSessionCaches?.();
     const store = useTerminalStore.getState();
     store.loadCopilotSessions();
     store.loadClaudeCodeSessions();
@@ -876,8 +899,31 @@ const CopilotPanel: React.FC = () => {
         onKeyDown={handleKeyDown}
       />
 
+      {hasMore && !query && (
+        <div style={{ display: 'flex', gap: '6px', padding: '4px 8px', fontSize: '11px', alignItems: 'center' }}>
+          <span style={{ opacity: 0.6 }}>Loaded {totalLoaded} of {totalEligible}</span>
+          <button
+            className="dir-panel-close"
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            style={{ fontSize: '11px', padding: '1px 6px', cursor: loadingMore ? 'wait' : 'pointer' }}
+          >
+            {loadingMore ? '…' : '+100'}
+          </button>
+          <button
+            className="dir-panel-close"
+            onClick={handleLoadAll}
+            disabled={loadingMore}
+            title={totalEligible > 1000 ? `Load all ${totalEligible.toLocaleString()} sessions (may use significant memory)` : `Load all ${totalEligible.toLocaleString()} sessions`}
+            style={{ fontSize: '11px', padding: '1px 6px', cursor: loadingMore ? 'wait' : 'pointer' }}
+          >
+            {loadingMore ? '…' : 'All'}
+          </button>
+        </div>
+      )}
+
       <div className="dir-panel-list" ref={listRef}>
-        {displayList.map((session, index) => {
+        {displayList.slice(0, renderLimit).map((session, index) => {
           const title = getTitle(session);
           const subtitle = getSubtitle(session);
           const active = isActiveStatus(session.status);
@@ -1031,6 +1077,14 @@ const CopilotPanel: React.FC = () => {
             </React.Fragment>
           );
         })}
+        {displayList.length > renderLimit && (
+          <div
+            style={{ padding: '8px', textAlign: 'center', fontSize: '11px', opacity: 0.7, cursor: 'pointer' }}
+            onClick={() => setRenderLimit(r => r + 200)}
+          >
+            Showing {renderLimit} of {displayList.length} — click to show more
+          </div>
+        )}
         {displayList.length === 0 && (
           <div className="dir-panel-empty">
             {lifecycleTab === 'active' && allCount === 0

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -612,6 +612,14 @@ interface TerminalStore {
   aiSessionHighlightRequest: number;
   copilotSessions: CopilotSessionSummary[];
   claudeCodeSessions: CopilotSessionSummary[];
+  /** Total eligible Copilot sessions on disk (may be larger than copilotSessions.length) */
+  copilotSessionsTotal: number;
+  /** Total eligible Claude Code sessions on disk */
+  claudeCodeSessionsTotal: number;
+  /** Current load limit for Copilot sessions */
+  copilotSessionsLimit: number;
+  /** Current load limit for Claude Code sessions */
+  claudeCodeSessionsLimit: number;
   sessionNameOverrides: Record<string, string>;
   sessionLifecycleOverrides: Record<string, import('../../shared/copilot-types').SessionLifecycle>;
   /** Session IDs the user has pinned to the top of the AI sessions list */
@@ -751,6 +759,8 @@ interface TerminalStore {
   // right aiSessionId) and bumps aiSessionHighlightRequest.
   showAiSessionsForPane: (terminalId: TerminalId) => void;
   loadCopilotSessions: () => Promise<void>;
+  loadMoreSessions: (extra: number) => Promise<void>;
+  loadAllSessions: () => Promise<void>;
   searchCopilotSessions: (query: string) => Promise<void>;
   openCopilotSession: (sessionId: string) => Promise<void>;
   setCopilotSessions: (sessions: CopilotSessionSummary[]) => void;
@@ -858,6 +868,10 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   sessionSummaryRequest: null,
   copilotSessions: [],
   claudeCodeSessions: [],
+  copilotSessionsTotal: 0,
+  claudeCodeSessionsTotal: 0,
+  copilotSessionsLimit: 50,
+  claudeCodeSessionsLimit: 50,
   sessionNameOverrides: {},
   sessionLifecycleOverrides: {},
   sessionPinned: {},
@@ -2834,16 +2848,53 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   },
 
   loadCopilotSessions: async () => {
-    const sessions = await (window.terminalAPI as any).listCopilotSessions();
-    set({ copilotSessions: sessions ?? [] });
+    const limit = get().copilotSessionsLimit;
+    const result = await (window.terminalAPI as any).listCopilotSessions(limit);
+    // Handle both new { sessions, totalEligible } shape and legacy array
+    const sessions = Array.isArray(result) ? result : (result?.sessions ?? []);
+    const totalEligible = Array.isArray(result) ? sessions.length : (result?.totalEligible ?? sessions.length);
+    set({ copilotSessions: sessions, copilotSessionsTotal: totalEligible });
     get().autoArchiveStaleSessions();
+  },
+
+  loadMoreSessions: async (extra: number) => {
+    const { copilotSessionsLimit, claudeCodeSessionsLimit } = get();
+    const newCopilotLimit = copilotSessionsLimit + extra;
+    const newClaudeLimit = claudeCodeSessionsLimit + extra;
+    set({ copilotSessionsLimit: newCopilotLimit, claudeCodeSessionsLimit: newClaudeLimit });
+    const [copilotResult, claudeResult] = await Promise.all([
+      (window.terminalAPI as any).listCopilotSessions(newCopilotLimit),
+      (window.terminalAPI as any).listClaudeCodeSessions(newClaudeLimit),
+    ]);
+    const cSessions = Array.isArray(copilotResult) ? copilotResult : (copilotResult?.sessions ?? []);
+    const cTotal = Array.isArray(copilotResult) ? cSessions.length : (copilotResult?.totalEligible ?? cSessions.length);
+    const ccSessions = Array.isArray(claudeResult) ? claudeResult : (claudeResult?.sessions ?? []);
+    const ccTotal = Array.isArray(claudeResult) ? ccSessions.length : (claudeResult?.totalEligible ?? ccSessions.length);
+    set({ copilotSessions: cSessions, copilotSessionsTotal: cTotal, claudeCodeSessions: ccSessions, claudeCodeSessionsTotal: ccTotal });
+  },
+
+  loadAllSessions: async () => {
+    const MAX = 999999;
+    set({ copilotSessionsLimit: MAX, claudeCodeSessionsLimit: MAX });
+    const [copilotResult, claudeResult] = await Promise.all([
+      (window.terminalAPI as any).listCopilotSessions(MAX),
+      (window.terminalAPI as any).listClaudeCodeSessions(MAX),
+    ]);
+    const cSessions = Array.isArray(copilotResult) ? copilotResult : (copilotResult?.sessions ?? []);
+    const cTotal = Array.isArray(copilotResult) ? cSessions.length : (copilotResult?.totalEligible ?? cSessions.length);
+    const ccSessions = Array.isArray(claudeResult) ? claudeResult : (claudeResult?.sessions ?? []);
+    const ccTotal = Array.isArray(claudeResult) ? ccSessions.length : (claudeResult?.totalEligible ?? ccSessions.length);
+    set({ copilotSessions: cSessions, copilotSessionsTotal: cTotal, claudeCodeSessions: ccSessions, claudeCodeSessionsTotal: ccTotal });
   },
 
   searchCopilotSessions: async (query: string) => {
     set({ copilotSearchQuery: query });
     if (!query.trim()) {
-      const sessions = await (window.terminalAPI as any).listCopilotSessions();
-      set({ copilotSessions: sessions ?? [] });
+      const limit = get().copilotSessionsLimit;
+      const result = await (window.terminalAPI as any).listCopilotSessions(limit);
+      const sessions = Array.isArray(result) ? result : (result?.sessions ?? []);
+      const totalEligible = Array.isArray(result) ? sessions.length : (result?.totalEligible ?? sessions.length);
+      set({ copilotSessions: sessions, copilotSessionsTotal: totalEligible });
       return;
     }
     const sessions = await (window.terminalAPI as any).searchCopilotSessions(query);
@@ -3036,15 +3087,21 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
 
   // ── Claude Code session actions ────────────────────────────────────
   loadClaudeCodeSessions: async () => {
-    const sessions = await (window.terminalAPI as any).listClaudeCodeSessions();
-    set({ claudeCodeSessions: sessions ?? [] });
+    const limit = get().claudeCodeSessionsLimit;
+    const result = await (window.terminalAPI as any).listClaudeCodeSessions(limit);
+    const sessions = Array.isArray(result) ? result : (result?.sessions ?? []);
+    const totalEligible = Array.isArray(result) ? sessions.length : (result?.totalEligible ?? sessions.length);
+    set({ claudeCodeSessions: sessions, claudeCodeSessionsTotal: totalEligible });
     get().autoArchiveStaleSessions();
   },
 
   searchClaudeCodeSessions: async (query: string) => {
     if (!query.trim()) {
-      const sessions = await (window.terminalAPI as any).listClaudeCodeSessions();
-      set({ claudeCodeSessions: sessions ?? [] });
+      const limit = get().claudeCodeSessionsLimit;
+      const result = await (window.terminalAPI as any).listClaudeCodeSessions(limit);
+      const sessions = Array.isArray(result) ? result : (result?.sessions ?? []);
+      const totalEligible = Array.isArray(result) ? sessions.length : (result?.totalEligible ?? sessions.length);
+      set({ claudeCodeSessions: sessions, claudeCodeSessionsTotal: totalEligible });
       return;
     }
     const sessions = await (window.terminalAPI as any).searchClaudeCodeSessions(query);

--- a/src/shared/copilot-types.ts
+++ b/src/shared/copilot-types.ts
@@ -51,7 +51,6 @@ export interface CopilotSession {
   messageCount: number;
   toolCallCount: number;
   lastActivityTime: number;
-  timeline: CopilotActivityEntry[];
   pendingToolCalls: number;
   totalTokens: number;
   latestPrompt?: string;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -28,6 +28,7 @@ export const IPC = {
   COPILOT_START_WATCHING: 'copilot:startWatching',
   COPILOT_STOP_WATCHING: 'copilot:stopWatching',
   COPILOT_GET_PROMPTS: 'copilot:getPrompts',
+  AI_INVALIDATE_CACHES: 'ai:invalidateCaches',
   CLAUDE_CODE_LIST_SESSIONS: 'claude-code:listSessions',
   CLAUDE_CODE_GET_SESSION: 'claude-code:getSession',
   CLAUDE_CODE_SEARCH_SESSIONS: 'claude-code:searchSessions',


### PR DESCRIPTION
# Fix: OOM crash and startup freeze with large number of AI sessions

## Problem

Users with 1,000+ Copilot sessions experience OOM crashes or 2-3 minute freezes on startup. The app scans every session directory synchronously, parses all JSONL files into memory, and retains every parsed event object in an unbounded cache. With ~6,200 eligible sessions and ~2.4 GB of events data, this exhausts the V8 heap.

Additionally, a 5-second stale check timer re-runs the full scan repeatedly, blocking the main process for ~600-900ms each cycle and causing periodic input lag.

## Changes

### Session scan limit and caching
- `scanSessions()` now accepts a `limit` parameter (default 50), sorts candidates by mtime, and only parses the top N
- First scan builds a sorted candidate list from stat() calls; subsequent scans reuse the cache (0.1ms vs 600ms)
- Chokidar watcher events update the candidate cache (new sessions inserted, removed sessions evicted, active sessions promoted to front)

### Parser memory fix
- **Copilot events parser** rewritten to store only derived aggregate state (status, counters, latest prompt, recent prompts) instead of every raw event object. Follows the same pattern Claude Code parser already used. A 60MB JSONL now uses ~1KB of cache.
- `CopilotSession.timeline` field removed (was populated but never consumed by any code path)

### Stale check optimization
- Timer callback now calls `refreshLoadedSessions()` (re-checks only non-idle in-memory sessions) instead of `scanSessions()` (which re-statted all directories)
- Copilot watcher interval changed from 5s to 10s

### IPC changes
- `COPILOT_LIST_SESSIONS` / `CLAUDE_CODE_LIST_SESSIONS` now accept a `limit` parameter and return `{ sessions, totalEligible }` instead of a plain array
- Store handles both shapes for backward compatibility
- New `AI_INVALIDATE_CACHES` IPC channel wired to the refresh button

### UI: Load more
- AI Sessions panel shows "Loaded X of Y" with "+100" and "All" buttons when there are more sessions than loaded
- "All" shows a confirmation dialog when >1000 sessions
- Render list capped at 200 DOM nodes with "click to show more" at bottom
- Sessions stream in progressively during load via `onSessionAdded` callbacks

### Async and yielding
- IPC handlers are now async
- Parse loop yields to event loop every 10 sessions via `setImmediate` so UI stays responsive during +100/All
- WSL scan methods converted to async

## Known limitations (follow-up work)

1. **Search is scoped to loaded sessions** - `searchSessions()` only searches the in-memory session set (default top 50). Users must click "+100" or "All" to widen the searchable set first. Previously search covered all ~6,200 sessions (but at the cost of loading them all into memory). A proper fix would lazily search the candidate cache or use an async search-on-demand pattern.

2. **WSL scan doesn't forward the limit parameter** - WSL session scanning always uses the default limit of 50 per distro. Users with 50+ sessions inside a single WSL distro won't see all of them. Low impact since this is a rare scenario.

3. **Initial stat phase is still synchronous** - The first scan stats all directories synchronously (~300-600ms for 6,500 dirs). Subsequent scans use the cache. Converting to async stat was attempted but `fs.promises.stat` with thousands of concurrent calls was 70x slower due to microtask overhead.

## Testing

Tested with 6,500+ Copilot session directories:
- Startup: no OOM, no freeze, window appears instantly
- +100: sessions stream in progressively, UI stays responsive
- Refresh button: invalidates cache and re-scans
- Stale timer: only refreshes non-idle sessions, no main-process blocking
