### PR TITLE
PR: liranazran/fix-md-preview-bug

### DIFF
--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -11,6 +11,7 @@ import { isMac } from '../utils/platform';
 import { runJumpToPromptSearch } from '../utils/jump-to-prompt';
 import { prepareClipboardPaste, resolveClipboardPaste } from '../utils/paste';
 import { smartUnwrapForCopy } from '../utils/smart-unwrap';
+import { MD_PATH_PATTERN } from '../utils/md-link-parser';
 import type { AppConfig } from '../state/types';
 import '@xterm/xterm/css/xterm.css';
 
@@ -603,8 +604,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
         const line = term.buffer.active.getLine(bufferLineNumber - 1);
         if (!line) { callback(undefined); return; }
         const text = line.translateToString();
-        // Match file paths ending in .md (absolute or relative)
-        const mdPathRegex = /(?:[a-zA-Z]:[\\/]|[\/~.])?[^\s"'`<>|:*?]*\.md\b/gi;
+        // Single source of truth for the .md path pattern lives in
+        // utils/md-link-parser. Build a fresh stateful instance per call so
+        // `lastIndex` is never shared across providers.
+        const mdPathRegex = new RegExp(MD_PATH_PATTERN, 'gi');
         const links: Array<{ range: { start: { x: number; y: number }; end: { x: number; y: number } }; text: string; activate: () => void; tooltip: string }> = [];
         let match: RegExpExecArray | null;
         while ((match = mdPathRegex.exec(text)) !== null) {

--- a/src/renderer/utils/md-link-parser.tsx
+++ b/src/renderer/utils/md-link-parser.tsx
@@ -1,8 +1,24 @@
 import React from 'react';
 import { useTerminalStore } from '../state/terminal-store';
 
-// Regex matching file paths ending in .md
-const MD_PATH_REGEX = /(?:[a-zA-Z]:[\\/]|[\/~.])?[^\s"'`<>|:*?]*\.md\b/g;
+// Regex matching file paths ending in .md.
+//
+// Two alternatives, tried in order at each position:
+//   1. Anchored at a real path prefix (Windows drive `C:\`, UNC `\\server`,
+//      leading `/`, `~/`, `./`, `../`) - allows spaces in the body so paths
+//      like `C:\Users\foo\OneDrive - Microsoft\Obsidian Vault\note.md` match
+//      end-to-end. Lazy `+?` stops at the FIRST `.md\b`, so adjacent paths in
+//      the same line stay separate. `:` is excluded from the body because no
+//      legitimate path has a colon after the drive letter, which keeps the
+//      match from running across URL fragments.
+//   2. Bare filename with no prefix (e.g. `README.md`) - no spaces allowed,
+//      otherwise we'd grab arbitrary surrounding prose.
+//
+// Single source of truth - imported by TerminalPanel's xterm link provider so
+// the in-chat parser and the in-terminal provider can never drift apart.
+// Pattern is a string (not a literal RegExp) so consumers always build a
+// fresh stateful instance and `lastIndex` is never shared across callers.
+export const MD_PATH_PATTERN = '(?:[A-Za-z]:[\\\\/]|~[\\\\/]|\\.{1,2}[\\\\/]|[\\\\/])[^"\'`<>|:*?\\r\\n]+?\\.md\\b|[^\\s"\'`<>|:*?\\r\\n]+\\.md\\b';
 
 function isAbsolutePath(p: string): boolean {
   return /^[a-zA-Z]:/.test(p) || p.startsWith('/') || p.startsWith('~');
@@ -23,7 +39,7 @@ export function renderWithMdLinks(text: string, cwd?: string): React.ReactNode {
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
-  const regex = new RegExp(MD_PATH_REGEX.source, 'g');
+  const regex = new RegExp(MD_PATH_PATTERN, 'g');
 
   while ((match = regex.exec(text)) !== null) {
     if (match.index > lastIndex) {


### PR DESCRIPTION
# Fix `.md` path detection for paths containing spaces

## Problem
Ctrl+Click on a markdown path with spaces (e.g.
`C:\Users\example\OneDrive - Microsoft\Documents\exmaple Vault\Agents\Docs\grafana-mcp-onboarding.md`)
opened the wrong file or did nothing — the regex's body excluded `\s`, so the
match was cut off at the first space and `fileRead` got a broken substring.

## Fix
Two-branch regex that's smart about anchoring:

1. **Anchored branch** (drive letter, UNC `\\server`, leading `/`, `~/`, `./`,
   `../`): allows spaces in the body, lazy `+?` stops at the first `.md\b`.
   Adjacent paths on the same line stay separate.
2. **Bare branch** (e.g. `README.md`): keeps the no-spaces rule so we don't
   eat surrounding prose.

`:` stays excluded from the body — no real path has a colon after the drive
letter, and this keeps matches from running across URL fragments.

## Decoupling
Both call sites (chat-side `renderWithMdLinks` in `md-link-parser.tsx` and
the xterm link provider in `TerminalPanel.tsx`) used to hold their own
copy of the regex. Now there's a single exported `MD_PATH_PATTERN` string
in `md-link-parser.tsx`; `TerminalPanel` imports it and builds a fresh
`RegExp` per call (so `lastIndex` is never shared).

## Verification
15 cases covering Windows drives, UNC, POSIX absolute, `~/`, `./`, `../`,
bare filenames, multiple paths per line, paths with spaces, trailing
punctuation, and newline boundaries — all pass.

## Files changed
- `src/renderer/utils/md-link-parser.tsx` — new exported `MD_PATH_PATTERN`
- `src/renderer/components/TerminalPanel.tsx` — imports and uses it
