### PR TITLE
feat(panel): middle-click pane title bar to close (TASK-107)

### DIFF
--- a/backlog/tasks/task-107 - Middle-click-on-pane-title-bar-closes-the-terminal.md
+++ b/backlog/tasks/task-107 - Middle-click-on-pane-title-bar-closes-the-terminal.md
@@ -1,0 +1,61 @@
+---
+id: TASK-107
+title: Middle-click on pane title bar closes the terminal
+status: Done
+assignee:
+  - '@Tomer Solomon'
+created_date: '2026-05-04 16:03'
+updated_date: '2026-05-04 16:17'
+labels: []
+dependencies: []
+references:
+  - src/renderer/components/TerminalPanel.tsx
+  - src/renderer/components/TabBar.tsx
+  - src/renderer/components/FloatingPanel.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Mirror the existing tab middle-click-to-close UX onto the per-pane title bar so users can quickly close a tiled or floating terminal pane by middle-clicking its title bar. Today only the small X icon in the status-dot container or the right-click menu can close a pane via mouse on the title bar. Tabs in TabBar.tsx already support middle-click anywhere on the tab to close (lines 94-102); the per-pane title bar in TerminalPanel.tsx (around line 2000) does not. The per-pane title bar is shared between tiled panes and floating panels so a single change covers both.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Middle-clicking on the title bar of a tiled terminal pane closes that terminal
+- [x] #2 Middle-clicking on the title bar of a floating panel closes that terminal and removes it from the floating-panels list
+- [x] #3 Middle-clicking on the status-dot/X area or on a button inside the title bar does not trigger the new close path
+- [x] #4 Middle-clicking on the rename input while a pane is being renamed does not close the terminal
+- [x] #5 Existing left-button drag of a floating panel via its title bar continues to work unchanged
+- [x] #6 Existing tab middle-click close in TabBar continues to work unchanged
+- [x] #7 A new Playwright spec under tests/e2e/ covers the cases above and passes via npm run test:e2e
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read TerminalPanel.tsx around line 2000 to confirm exact insertion point.
+2. Add an .button === 1 branch at the top of the existing title-bar onMouseDown that: (a) bails if target is inside button/input/.status-dot-container, (b) calls preventDefault + stopPropagation, (c) calls useTerminalStore.getState().closeTerminal(terminalId), (d) returns early.
+3. Add tests/e2e/middle-click-titlebar-close.spec.ts modeled on tests/e2e/float-shortcut.spec.ts, covering: tiled close, floating close, status-dot no-op, rename input no-op.
+4. Run npm run test:e2e -- middle-click-titlebar-close.
+5. Run npm start and manually verify on Windows.
+6. Commit with Co-authored-by trailer; open PR.
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a middle-click-to-close handler on the per-pane title bar (.terminal-pane-title) in TerminalPanel.tsx. Mirrors the existing tab middle-click-close UX from TabBar so the same gesture works uniformly on tiled panes and floating panels (both render the same title-bar element).
+
+Changes:
+- src/renderer/components/TerminalPanel.tsx: prepended an e.button === 1 branch to the existing title-bar onMouseDown. Bails when the target is inside a button, input, or .status-dot-container so the rename input, X icon, and any nested buttons keep their existing semantics. preventDefault suppresses Windows' middle-button auto-scroll cursor; closeTerminal(terminalId) handles the actual close.
+- tests/e2e/middle-click-titlebar-close.spec.ts: new Playwright spec covering tiled close, floating close, status-dot/X no-op, and rename-input no-op.
+
+Tests:
+- npm run test:e2e -- middle-click-titlebar-close → 4/4 passing.
+
+Risks/notes:
+- xterm Linux middle-click paste is unaffected (handler scoped to the title bar, not the xterm canvas).
+- The pane root's onMouseDownCapture still calls handleFocus() before our handler runs; harmless because the doomed pane is closed a tick later and the store re-focuses a survivor.
+- Multi-select close-all is intentionally not part of this change (matches tab behavior). Could be a follow-up.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -2219,6 +2219,21 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
           className={`terminal-pane-title${floatTitleBar ? ' float-titlebar' : ''}${isMultiSelected ? ' multi-selected' : ''}`}
           style={bgTint ? { background: bgTint + (isFocused ? '66' : '33') } : undefined}
           onMouseDown={(e) => {
+            // TASK-107: Middle-click on the title bar closes the pane,
+            // mirroring the tab middle-click-close UX in TabBar. Bail when
+            // the click lands on an interactive child (button, rename input,
+            // status-dot/X icon) so those keep their existing behavior.
+            // preventDefault suppresses Windows' middle-button auto-scroll.
+            if (e.button === 1) {
+              const t = e.target as HTMLElement;
+              if (t.closest('button') || t.closest('input') || t.closest('.status-dot-container')) {
+                return;
+              }
+              e.preventDefault();
+              e.stopPropagation();
+              useTerminalStore.getState().closeTerminal(terminalId);
+              return;
+            }
             // TASK-72: Ctrl/Cmd+click on the title bar toggles this pane in
             // the multi-selection set. Bound to the title bar (not the
             // xterm canvas area) so terminal text selection / focus stays

--- a/tests/e2e/middle-click-titlebar-close.spec.ts
+++ b/tests/e2e/middle-click-titlebar-close.spec.ts
@@ -1,0 +1,207 @@
+import { test, expect, Page } from '@playwright/test';
+import { launchTmax } from './fixtures/launch';
+
+// TASK-107: Middle-clicking a terminal pane's title bar closes that pane,
+// mirroring the existing tab middle-click-close UX (TabBar.tsx). The
+// handler lives on `.terminal-pane-title` in TerminalPanel.tsx so the
+// behavior covers both tiled panes and floating panels (which share the
+// same title-bar element). Interactive children (rename input, the
+// status-dot/X container, and any nested buttons) are excluded so they
+// keep their existing click semantics.
+
+async function terminalCount(window: Page): Promise<number> {
+  return window.evaluate(() => {
+    const store = (window as any).__terminalStore;
+    return store.getState().terminals.size as number;
+  });
+}
+
+async function setPaneTitle(window: Page, terminalId: string, title: string): Promise<void> {
+  // Brand-new dev panes initialize their title from the first PTY output,
+  // which lags. Force-set a title so .terminal-pane-title renders
+  // deterministically. Same trick used by rename-doesnt-close.spec.ts.
+  await window.evaluate(({ tid, t }) => {
+    const store = (window as any).__terminalStore;
+    const s = store.getState();
+    const map = new Map(s.terminals);
+    const inst = map.get(tid);
+    map.set(tid, { ...inst, title: t });
+    store.setState({ terminals: map });
+  }, { tid: terminalId, t: title });
+}
+
+test('middle-click on a tiled pane title bar closes that terminal', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForSelector('.terminal-panel', { timeout: 15_000 });
+    await window.waitForTimeout(800);
+
+    // Add a second terminal so closing one doesn't tear down the app.
+    await window.keyboard.press('Control+t');
+    await window.waitForFunction(
+      () => ((window as any).__terminalStore.getState().terminals.size as number) >= 2,
+      null,
+      { timeout: 5_000 },
+    );
+
+    const ids: string[] = await window.evaluate(() => {
+      const s = (window as any).__terminalStore.getState();
+      return Array.from(s.terminals.keys()) as string[];
+    });
+    expect(ids.length).toBeGreaterThanOrEqual(2);
+    const targetId = ids[0];
+
+    await setPaneTitle(window, targetId, 'middle-click-close-tiled');
+    await window.waitForSelector(`[data-terminal-id="${targetId}"] .terminal-pane-title-text`, { timeout: 3_000 });
+
+    const before = await terminalCount(window);
+    await window
+      .locator(`[data-terminal-id="${targetId}"] .terminal-pane-title-text`)
+      .click({ button: 'middle' });
+
+    await window.waitForFunction(
+      (tid) => !((window as any).__terminalStore.getState().terminals.has(tid)),
+      targetId,
+      { timeout: 3_000 },
+    );
+    expect(await terminalCount(window)).toBe(before - 1);
+  } finally {
+    await close();
+  }
+});
+
+test('middle-click on a floating panel title bar closes that terminal', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForSelector('.terminal-panel', { timeout: 15_000 });
+    await window.waitForTimeout(800);
+
+    // Need 2 terminals so closing the floating one leaves the app alive.
+    await window.keyboard.press('Control+t');
+    await window.waitForFunction(
+      () => ((window as any).__terminalStore.getState().terminals.size as number) >= 2,
+      null,
+      { timeout: 5_000 },
+    );
+
+    const focusedId: string = await window.evaluate(() => {
+      const s = (window as any).__terminalStore.getState();
+      return s.focusedTerminalId ?? Array.from(s.terminals.keys())[0];
+    });
+
+    // Float the focused pane via the same shortcut covered by float-shortcut.spec.ts.
+    await window.keyboard.press('Control+Shift+u');
+    await window.waitForFunction(
+      (tid) => {
+        const s = (window as any).__terminalStore.getState();
+        return s.terminals.get(tid)?.mode === 'floating';
+      },
+      focusedId,
+      { timeout: 3_000 },
+    );
+
+    await setPaneTitle(window, focusedId, 'middle-click-close-floating');
+    await window.waitForSelector(`[data-terminal-id="${focusedId}"] .terminal-pane-title.float-titlebar`, { timeout: 3_000 });
+
+    await window
+      .locator(`[data-terminal-id="${focusedId}"] .terminal-pane-title-text`)
+      .click({ button: 'middle' });
+
+    await window.waitForFunction(
+      (tid) => {
+        const s = (window as any).__terminalStore.getState();
+        const goneFromTerminals = !s.terminals.has(tid);
+        const goneFromFloating = !s.layout.floatingPanels.some((p: any) => p.terminalId === tid);
+        return goneFromTerminals && goneFromFloating;
+      },
+      focusedId,
+      { timeout: 3_000 },
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('middle-click on the status-dot/X container does NOT close the pane', async () => {
+  // The status-dot container hosts the pane's existing X close affordance,
+  // which is bound to onClick (left-click only). Our new handler must
+  // exclude this region so middle-click here is a true no-op rather than
+  // an accidental second close path.
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForSelector('.terminal-panel', { timeout: 15_000 });
+    await window.waitForTimeout(800);
+
+    await window.keyboard.press('Control+t');
+    await window.waitForFunction(
+      () => ((window as any).__terminalStore.getState().terminals.size as number) >= 2,
+      null,
+      { timeout: 5_000 },
+    );
+
+    const targetId: string = await window.evaluate(() => {
+      const s = (window as any).__terminalStore.getState();
+      return s.focusedTerminalId ?? Array.from(s.terminals.keys())[0];
+    });
+    await setPaneTitle(window, targetId, 'middle-click-status-dot');
+    await window.waitForSelector(`[data-terminal-id="${targetId}"] .status-dot-container`, { timeout: 3_000 });
+
+    const before = await terminalCount(window);
+    await window
+      .locator(`[data-terminal-id="${targetId}"] .status-dot-container`)
+      .click({ button: 'middle' });
+    await window.waitForTimeout(300);
+
+    const stillExists = await window.evaluate(
+      (tid) => (window as any).__terminalStore.getState().terminals.has(tid),
+      targetId,
+    );
+    expect(stillExists).toBe(true);
+    expect(await terminalCount(window)).toBe(before);
+  } finally {
+    await close();
+  }
+});
+
+test('middle-click on the rename input does NOT close the pane while renaming', async () => {
+  // While a pane is being renamed, the title text is replaced by an
+  // <input>. The handler must skip the close path when the click target
+  // is inside an input so users editing a name don't lose their pane.
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForSelector('.terminal-panel', { timeout: 15_000 });
+    await window.waitForTimeout(800);
+
+    await window.keyboard.press('Control+t');
+    await window.waitForFunction(
+      () => ((window as any).__terminalStore.getState().terminals.size as number) >= 2,
+      null,
+      { timeout: 5_000 },
+    );
+
+    const targetId: string = await window.evaluate(() => {
+      const s = (window as any).__terminalStore.getState();
+      return s.focusedTerminalId ?? Array.from(s.terminals.keys())[0];
+    });
+    await setPaneTitle(window, targetId, 'middle-click-rename');
+    await window.waitForSelector(`[data-terminal-id="${targetId}"] .terminal-pane-title-text`, { timeout: 3_000 });
+
+    await window.dblclick(`[data-terminal-id="${targetId}"] .terminal-pane-title-text`);
+    await window.waitForSelector(`[data-terminal-id="${targetId}"] .pane-rename-input`, { timeout: 3_000 });
+
+    const before = await terminalCount(window);
+    await window
+      .locator(`[data-terminal-id="${targetId}"] .pane-rename-input`)
+      .click({ button: 'middle' });
+    await window.waitForTimeout(300);
+
+    const stillExists = await window.evaluate(
+      (tid) => (window as any).__terminalStore.getState().terminals.has(tid),
+      targetId,
+    );
+    expect(stillExists).toBe(true);
+    expect(await terminalCount(window)).toBe(before);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
Mirrors the existing tab middle-click-close UX from TabBar onto the per-pane title bar so the same gesture works uniformly on tiled panes and floating panels (both render the same .terminal-pane-title element).

The new branch on the existing onMouseDown handler:
- Bails when the click target is inside a button, input, or .status-dot-container so the rename input, X icon, and any nested buttons keep their existing semantics.
- preventDefault suppresses Windows' middle-button auto-scroll cursor.
- Calls closeTerminal(terminalId) for the doomed pane.

Adds a Playwright spec covering: tiled close, floating close, status-dot/X no-op, and rename-input no-op (4/4 passing).