### PR TITLE
fix: sync rename between sidebar, tab, and Copilot /rename (#2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmax",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmax",
-      "version": "1.7.3",
+      "version": "1.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/copilot-session-monitor.ts
+++ b/src/main/copilot-session-monitor.ts
@@ -266,7 +266,13 @@ export class CopilotSessionMonitor {
         oldSession.messageCount !== session.messageCount ||
         oldSession.toolCallCount !== session.toolCallCount ||
         oldSession.latestPrompt !== session.latestPrompt ||
-        oldSession.workspace.summary !== session.workspace.summary)) {
+        oldSession.workspace.summary !== session.workspace.summary ||
+        // Issue #2 follow-up: `/rename` writes to workspace.yaml's `name`
+        // field (and sets `user_named: true`), NOT to `summary`. The
+        // original fix only watched `summary`, so CLI renames were silently
+        // dropped. Compare both so a CLI rename refreshes the UI.
+        oldSession.workspace.name !== session.workspace.name ||
+        oldSession.workspace.userNamed !== session.workspace.userNamed)) {
       this.callbacks.onSessionUpdated?.(summary);
     }
 
@@ -509,11 +515,28 @@ export class CopilotSessionMonitor {
           case 'summary':
             result.summary = value;
             break;
+          // Issue #2 follow-up: the CLI's `/rename` writes the chosen
+          // title to `name:` (not `summary:`) and flips `user_named: true`.
+          // The original parser ignored both fields, so /rename never
+          // surfaced in the UI. Read them now and let the derivation
+          // block below honor the user's explicit choice.
+          case 'name':
+            result.name = value;
+            break;
+          case 'user_named':
+            result.userNamed = value === 'true' || value === 'True' || value === '1';
+            break;
         }
       }
 
-      // Derive display name: summary > repo > folder name
-      if (result.summary) {
+      // Derive display name: user-set name (CLI /rename) > summary > repo > folder name.
+      // When `user_named: true` we keep whatever the CLI wrote — even if
+      // summary or other fields would otherwise win — and seed `summary`
+      // with the same value so the renderer (which reads `summary`) shows
+      // the user's chosen name.
+      if (result.userNamed && result.name && result.name !== path.basename(sessionDir)) {
+        result.summary = result.name;
+      } else if (result.summary) {
         result.name = result.summary;
       } else if (result.repository) {
         result.name = result.repository.split('/').pop() || result.repository;

--- a/src/main/copilot-session-monitor.ts
+++ b/src/main/copilot-session-monitor.ts
@@ -265,7 +265,8 @@ export class CopilotSessionMonitor {
     if (oldSession && (oldSession.status !== session.status ||
         oldSession.messageCount !== session.messageCount ||
         oldSession.toolCallCount !== session.toolCallCount ||
-        oldSession.latestPrompt !== session.latestPrompt)) {
+        oldSession.latestPrompt !== session.latestPrompt ||
+        oldSession.workspace.summary !== session.workspace.summary)) {
       this.callbacks.onSessionUpdated?.(summary);
     }
 

--- a/src/main/copilot-session-watcher.ts
+++ b/src/main/copilot-session-watcher.ts
@@ -75,7 +75,7 @@ export class CopilotSessionWatcher {
       const sessionId = this.extractSessionId(filePath);
       if (!sessionId) return;
 
-      if (filePath.endsWith('events.jsonl')) {
+      if (filePath.endsWith('events.jsonl') || filePath.endsWith('workspace.yaml')) {
         this.callbacks.onEventsChanged(sessionId);
       }
     });

--- a/src/renderer/components/CopilotPanel.tsx
+++ b/src/renderer/components/CopilotPanel.tsx
@@ -316,7 +316,17 @@ const CopilotPanel: React.FC = () => {
     let all = [
       ...copilotSessions.filter((s) => s.messageCount > 0).map((s) => ({ ...s, provider: s.provider || 'copilot' as const })),
       ...claudeCodeSessions.filter((s) => s.messageCount > 0).map((s) => ({ ...s, provider: s.provider || 'claude-code' as const })),
-    ].map((s) => summaryOverrides[s.id] ? { ...s, summary: summaryOverrides[s.id] } : s);
+    ].map((s) => {
+      // If user has a sidebar override, use it
+      if (summaryOverrides[s.id]) return { ...s, summary: summaryOverrides[s.id] };
+      // If a linked terminal has a custom title (user renamed via tab), derive from it
+      for (const [, t] of terminals) {
+        if (t.aiSessionId === s.id && t.customTitle && !t.aiAutoTitle) {
+          return { ...s, summary: t.title };
+        }
+      }
+      return s;
+    });
 
     // Filter by provider
     if (filterTab !== 'all') {
@@ -344,7 +354,7 @@ const CopilotPanel: React.FC = () => {
       : deduped.filter((s) => getSessionLifecycle(s) === lifecycleTab);
 
     return sortSessions(lifecycleFiltered, openSessionIds, pinnedSessions, sortMode);
-  }, [copilotSessions, claudeCodeSessions, query, filterTab, showRunningOnly, summaryOverrides, lifecycleTab, getSessionLifecycle, openSessionIds, pinnedSessions, sortMode]);
+  }, [copilotSessions, claudeCodeSessions, query, filterTab, showRunningOnly, summaryOverrides, terminals, lifecycleTab, getSessionLifecycle, openSessionIds, pinnedSessions, sortMode]);
 
   // #69: when groupByRepo is on, reorder filtered so sessions sharing a cwd
   // folder are contiguous. Group order depends on `groupOrder`:
@@ -574,6 +584,10 @@ const CopilotPanel: React.FC = () => {
     if (!renaming) return;
     const newSummary = renaming.value.trim();
     if (newSummary) {
+      // setSessionNameOverride atomically writes the sidebar override AND
+      // updates every linked terminal's title/customTitle/aiAutoTitle in one
+      // set(). No need to call renameTerminal() — that would trigger a
+      // redundant second setSessionNameOverride via its side effect.
       useTerminalStore.getState().setSessionNameOverride(renaming.id, newSummary);
     }
     setRenaming(null);

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -3719,7 +3719,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       const updatedTerminals = new Map(s.terminals);
       for (const [id, inst] of updatedTerminals) {
         if (inst.aiSessionId === sessionId) {
-          updatedTerminals.set(id, { ...inst, title: name, customTitle: true, aiAutoTitle: false });
+          updatedTerminals.set(id, { ...inst, title: name, customTitle: true, aiAutoTitle: false, firstCommandTitle: false });
         }
       }
       return {

--- a/src/shared/copilot-types.ts
+++ b/src/shared/copilot-types.ts
@@ -36,6 +36,13 @@ export interface CopilotWorkspaceMetadata {
   repository: string;
   name: string;
   summary: string;
+  /**
+   * True when the user explicitly renamed this session via the Copilot CLI
+   * `/rename` command. Persists in workspace.yaml as `user_named: true`.
+   * When true, the parser preserves the on-disk `name` value verbatim and
+   * skips any auto-derivation from summary/repo/cwd. Issue #2 follow-up.
+   */
+  userNamed?: boolean;
 }
 
 export interface CopilotActivityEntry {

--- a/tests/e2e/issue-2-rename-sync.spec.ts
+++ b/tests/e2e/issue-2-rename-sync.spec.ts
@@ -1,0 +1,328 @@
+import { test, expect, Page } from '@playwright/test';
+import { launchTmax } from './fixtures/launch';
+import type { CopilotSessionSummary } from '../../src/shared/copilot-types';
+
+// Issue #2 / commit 218dcef regression — three independent rename-sync bugs:
+//
+//   Bug 1 (watcher): copilot-session-watcher.ts only routed events.jsonl
+//                    changes; workspace.yaml writes were silently dropped,
+//                    so a /rename via the Copilot CLI never reached the UI.
+//
+//   Bug 2 (monitor): copilot-session-monitor.ts#refreshSession compared
+//                    status / messageCount / toolCallCount / latestPrompt
+//                    only — NOT summary. So even when the watcher routed
+//                    the workspace.yaml change, the monitor swallowed it.
+//
+//   Bug 3 (sidebar): CopilotPanel#handleFinishRename used a redundant
+//                    renameTerminal() loop that double-wrote and renamed
+//                    the wrong session. Fix simplifies to a single
+//                    setSessionNameOverride() call. setSessionNameOverride
+//                    now also resets firstCommandTitle:false on every
+//                    linked terminal (so the next shell command does NOT
+//                    overwrite the user's chosen name — TASK-88 regression
+//                    risk). And the sidebar useMemo now derives the
+//                    displayed summary from a linked terminal's customTitle
+//                    when there is no explicit override (so a tab-bar
+//                    rename flows back into the sidebar).
+//
+// These tests exercise Bug 3 end-to-end via the renderer + DOM (the user-
+// visible behaviour of all three bugs converges here). Bugs 1 + 2 live in
+// the main process file-watching layer and would require disk simulation;
+// they are covered indirectly by the visual sync tests below — if the
+// summary plumbing is broken upstream the rename will never be visible at
+// all.
+
+const SESSION_ID = 'issue-2-rename-sync-test';
+const UNIQUE_CWD = 'C:/test-issue-2-rename-sync-fixture-cwd';
+const ORIGINAL_SUMMARY = 'first prompt — comes from disk';
+const TAB_RENAME = 'name typed in the TAB bar';
+const SIDEBAR_RENAME = 'name typed in the SIDEBAR';
+
+function makeSession(overrides: Partial<CopilotSessionSummary> = {}): CopilotSessionSummary {
+  return {
+    id: SESSION_ID,
+    provider: 'copilot',
+    status: 'idle',
+    cwd: UNIQUE_CWD,
+    branch: 'main',
+    repository: 'tmax',
+    summary: ORIGINAL_SUMMARY,
+    slug: 'calm-river',
+    latestPrompt: ORIGINAL_SUMMARY,
+    latestPromptTime: Date.now(),
+    messageCount: 5,
+    toolCallCount: 0,
+    lastActivityTime: Date.now(),
+    ...overrides,
+  };
+}
+
+// Inject a fake CopilotSessionSummary into the store's copilotSessions
+// list AND open the AI sessions panel so it gets rendered. We REPLACE the
+// session lists (rather than appending) — but the main-process session
+// monitor watches the real ~/.copilot/session-state and keeps pushing
+// `addCopilotSession` updates for the real sessions on disk, so our
+// seeded session ends up in a crowded list. That's fine: tests below
+// locate OUR row via a unique fixture cwd (UNIQUE_CWD) rather than
+// `.first()`, so we never confuse it with a real session row.
+//
+// CRITICAL: loadCopilotSessions is the destructive `set({ copilotSessions: ... })`
+// that fires asynchronously on startup. If it fires AFTER our seed, it
+// silently wipes us. Three issues conspire:
+//   1. copilotSqliteActive flips true mid-load, before sessions are set,
+//      so we cannot use it as a "load done" signal.
+//   2. addCopilotSession from incremental monitor updates is benign (it
+//      filters by id and appends), so we don't need to defend against it.
+//   3. autoArchiveStaleSessions runs after every load and may flip our
+//      lifecycle to 'old' / 'archived' if it considers our session stale.
+//
+// Defence: monkey-patch loadCopilotSessions / setCopilotSessions to
+// no-ops AFTER waiting for the initial real load to settle. Then seed
+// our fixture session. Nothing can wipe it after that point.
+async function seedSessionAndOpenPanel(window: Page, session: CopilotSessionSummary): Promise<void> {
+  // Wait for the initial async session population to settle. The flag
+  // alone isn't enough (it flips early); poll until copilotSessions
+  // count is stable for ~600ms.
+  await window.waitForFunction(() => {
+    const w = window as any;
+    const s = w.__terminalStore.getState();
+    const now = s.copilotSessions.length;
+    const last = w.__lastCopilotCount;
+    const stableSince = w.__stableSince || 0;
+    if (now !== last) {
+      w.__lastCopilotCount = now;
+      w.__stableSince = Date.now();
+      return false;
+    }
+    return Date.now() - stableSince > 600;
+  }, null, { timeout: 20_000, polling: 200 });
+
+  await window.evaluate((s) => {
+    const store = (window as any).__terminalStore;
+    // Monkey-patch the destructive load actions so nothing can wipe our
+    // seed for the rest of the test. Incremental addCopilotSession is
+    // safe (filters by id) so we leave it alone.
+    store.setState({
+      loadCopilotSessions: async () => { /* test no-op */ },
+      setCopilotSessions: () => { /* test no-op */ },
+      autoArchiveStaleSessions: () => { /* test no-op — would override our lifecycle */ },
+      copilotSessions: [s, ...store.getState().copilotSessions.filter((x: any) => x.id !== s.id)],
+      sessionNameOverrides: {},
+      // Force lifecycle to 'active' explicitly so getSessionLifecycle's
+      // age check can never demote us to 'old'.
+      sessionLifecycleOverrides: { ...store.getState().sessionLifecycleOverrides, [s.id]: 'active' },
+      showCopilotPanel: true,
+    });
+  }, session);
+  // Wait for OUR specific seeded row to render — the unique cwd is on the
+  // row's title attribute (CopilotPanel sets title={session.cwd || session.id}).
+  await window.waitForSelector(`.ai-session-item[title="${UNIQUE_CWD}"]`, { timeout: 5_000 });
+}
+
+// Inject a fake terminal whose aiSessionId points at our seeded session.
+// Returns the generated terminal id so the caller can mutate it later.
+async function seedLinkedTerminal(
+  window: Page,
+  sessionId: string,
+  init: { title: string; customTitle: boolean; aiAutoTitle: boolean; firstCommandTitle?: boolean },
+): Promise<string> {
+  return window.evaluate(({ sessionId, init }) => {
+    const store = (window as any).__terminalStore;
+    const id = `e2e-fake-term-${Math.random().toString(36).slice(2, 8)}`;
+    const inst = {
+      id,
+      title: init.title,
+      customTitle: init.customTitle,
+      shellProfileId: 'pwsh',
+      cwd: 'C:/projects/tmax',
+      mode: 'tiled',
+      pid: 99999,
+      lastProcess: 'pwsh.exe',
+      startupCommand: '',
+      aiSessionId: sessionId,
+      aiAutoTitle: init.aiAutoTitle,
+      firstCommandTitle: init.firstCommandTitle ?? false,
+    };
+    const next = new Map(store.getState().terminals);
+    next.set(id, inst);
+    store.setState({ terminals: next });
+    return id;
+  }, { sessionId, init });
+}
+
+// Read the sidebar row's display name for OUR seeded session, located by
+// the unique fixture cwd. Returns null if our row hasn't rendered yet.
+async function readSidebarName(window: Page): Promise<string | null> {
+  const row = window.locator(`.ai-session-item[title="${UNIQUE_CWD}"]`).first();
+  if (await row.count() === 0) return null;
+  return row.locator('.ai-session-name').first().textContent({ timeout: 2_000 });
+}
+
+async function readTerminal(window: Page, terminalId: string): Promise<any> {
+  return window.evaluate((tid) => {
+    const inst = (window as any).__terminalStore.getState().terminals.get(tid);
+    if (!inst) return null;
+    const { id, title, customTitle, aiAutoTitle, firstCommandTitle, aiSessionId } = inst;
+    return { id, title, customTitle, aiAutoTitle, firstCommandTitle, aiSessionId };
+  }, terminalId);
+}
+
+test('Bug 3a — setSessionNameOverride writes title + 4 flags to all linked terminals', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await seedSessionAndOpenPanel(window, makeSession());
+
+    // Inject one linked terminal + one unlinked control in a SINGLE
+    // evaluate to avoid any cross-evaluate timing races (sequential
+    // setState calls don't race in zustand, but a single set is simpler
+    // to reason about and matches how the production renderer mounts
+    // pre-existing terminals on startup).
+    const ids = await window.evaluate(({ sessionId }) => {
+      const store = (window as any).__terminalStore;
+      const linkedId = `e2e-linked-${Math.random().toString(36).slice(2, 8)}`;
+      const unlinkedId = `e2e-unlinked-${Math.random().toString(36).slice(2, 8)}`;
+      const next = new Map(store.getState().terminals);
+      next.set(linkedId, {
+        id: linkedId, title: 'pre-rename', customTitle: false, shellProfileId: 'pwsh',
+        cwd: 'C:/projects/tmax', mode: 'tiled', pid: 99991, lastProcess: 'pwsh.exe', startupCommand: '',
+        aiSessionId: sessionId, aiAutoTitle: true, firstCommandTitle: true,
+      });
+      next.set(unlinkedId, {
+        id: unlinkedId, title: 'unrelated', customTitle: false, shellProfileId: 'pwsh',
+        cwd: 'C:/projects/tmax', mode: 'tiled', pid: 99992, lastProcess: 'pwsh.exe', startupCommand: '',
+        aiSessionId: 'OTHER-SESSION', aiAutoTitle: false, firstCommandTitle: false,
+      });
+      store.setState({ terminals: next });
+      return { linkedId, unlinkedId };
+    }, { sessionId: SESSION_ID });
+
+    // Fire the action that handleFinishRename now calls (post-fix).
+    await window.evaluate(({ sessionId, name }) => {
+      (window as any).__terminalStore.getState().setSessionNameOverride(sessionId, name);
+    }, { sessionId: SESSION_ID, name: SIDEBAR_RENAME });
+
+    // Linked terminal must carry the new title and ALL four flags
+    // (firstCommandTitle:false is the new addition that prevents the next
+    // shell command from re-stamping a different title — TASK-88 risk).
+    const linked = await readTerminal(window, ids.linkedId);
+    expect(linked, 'linked terminal must still exist after rename').not.toBeNull();
+    expect(linked.title).toBe(SIDEBAR_RENAME);
+    expect(linked.customTitle).toBe(true);
+    expect(linked.aiAutoTitle).toBe(false);
+    expect(linked.firstCommandTitle).toBe(false);
+
+    // Unlinked terminal must be untouched.
+    const unlinked = await readTerminal(window, ids.unlinkedId);
+    expect(unlinked, 'unlinked terminal must still exist').not.toBeNull();
+    expect(unlinked.title).toBe('unrelated');
+    expect(unlinked.customTitle).toBe(false);
+
+    // sessionNameOverrides map updated.
+    const overrides = await window.evaluate(() =>
+      (window as any).__terminalStore.getState().sessionNameOverrides);
+    expect(overrides[SESSION_ID]).toBe(SIDEBAR_RENAME);
+  } finally {
+    await close();
+  }
+});
+
+test('Bug 3b — sidebar derives display name from linked terminal customTitle (tab → sidebar sync)', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await seedSessionAndOpenPanel(window, makeSession());
+
+    // Baseline: with no linked terminal AND no override, the sidebar shows
+    // the on-disk summary.
+    await expect.poll(async () => readSidebarName(window), { timeout: 3_000 })
+      .toContain(ORIGINAL_SUMMARY);
+
+    // Simulate the user renaming via the TAB bar — that flows through
+    // renameTerminal() which sets customTitle:true and aiAutoTitle:false on
+    // the terminal but does NOT touch sessionNameOverrides.
+    await seedLinkedTerminal(window, SESSION_ID, {
+      title: TAB_RENAME, customTitle: true, aiAutoTitle: false, firstCommandTitle: false,
+    });
+
+    // Pre-fix: the sidebar would still display ORIGINAL_SUMMARY because
+    // CopilotPanel only consulted sessionNameOverrides. Post-fix: useMemo
+    // walks linked terminals and uses customTitle when present.
+    await expect.poll(async () => readSidebarName(window), { timeout: 3_000 })
+      .toContain(TAB_RENAME);
+
+    // Sanity: the on-disk summary text must not still be visible.
+    const name = (await readSidebarName(window)) ?? '';
+    expect(name).not.toContain(ORIGINAL_SUMMARY);
+  } finally {
+    await close();
+  }
+});
+
+test('Bug 3c — sessionNameOverrides beats linked terminal customTitle (precedence)', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await seedSessionAndOpenPanel(window, makeSession());
+
+    // Both signals present: a sidebar override AND a linked terminal with a
+    // different customTitle. The override branch is checked first in the
+    // useMemo so it must win.
+    await seedLinkedTerminal(window, SESSION_ID, {
+      title: TAB_RENAME, customTitle: true, aiAutoTitle: false, firstCommandTitle: false,
+    });
+    await window.evaluate(({ sessionId, name }) => {
+      // setSessionNameOverride would *also* mutate the terminal's title to
+      // match — bypass it here by writing the override map directly so the
+      // two strings stay distinct and we can prove which one the sidebar
+      // chose.
+      const store = (window as any).__terminalStore;
+      store.setState({
+        sessionNameOverrides: { ...store.getState().sessionNameOverrides, [sessionId]: name },
+      });
+    }, { sessionId: SESSION_ID, name: SIDEBAR_RENAME });
+
+    await expect.poll(async () => readSidebarName(window), { timeout: 3_000 })
+      .toContain(SIDEBAR_RENAME);
+    const name = (await readSidebarName(window)) ?? '';
+    expect(name).not.toContain(TAB_RENAME);
+    expect(name).not.toContain(ORIGINAL_SUMMARY);
+  } finally {
+    await close();
+  }
+});
+
+test('Bug 3d — firstCommandTitle is cleared so next shell command cannot overwrite the rename', async () => {
+  // This is the TASK-88 regression risk the fix specifically guards
+  // against. Pre-fix: setSessionNameOverride flipped customTitle=true and
+  // aiAutoTitle=false but left firstCommandTitle alone. So if a user
+  // renamed BEFORE typing their first command, the OSC-driven first-
+  // command title overwrite (terminal-store.ts ~3530) would still run on
+  // the next keystroke and clobber the rename.
+  //
+  // Post-fix: firstCommandTitle is forced to false in the same set(), so
+  // the first-command guard refuses to fire.
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await seedSessionAndOpenPanel(window, makeSession());
+
+    // Simulate a brand-new pane that has not seen its first command yet —
+    // firstCommandTitle starts true (pre-loaded by the watcher path).
+    const tid = await seedLinkedTerminal(window, SESSION_ID, {
+      title: 'placeholder', customTitle: false, aiAutoTitle: true, firstCommandTitle: true,
+    });
+
+    await window.evaluate(({ sessionId, name }) => {
+      (window as any).__terminalStore.getState().setSessionNameOverride(sessionId, name);
+    }, { sessionId: SESSION_ID, name: SIDEBAR_RENAME });
+
+    const inst = await readTerminal(window, tid);
+    expect(inst.firstCommandTitle).toBe(false);
+    expect(inst.title).toBe(SIDEBAR_RENAME);
+    expect(inst.customTitle).toBe(true);
+    expect(inst.aiAutoTitle).toBe(false);
+  } finally {
+    await close();
+  }
+});

--- a/tests/e2e/issue-2-rename-watcher.spec.ts
+++ b/tests/e2e/issue-2-rename-watcher.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+import { launchTmax } from './fixtures/launch';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// Issue #2 follow-up — Bug 1 (watcher routing workspace.yaml) and Bug 2 (monitor
+// diff comparing the right field) live in the main-process file-watching layer.
+// The original commit b86b24f tried to cover them with a single line each, but
+// shipped with the wrong field name in the diff (compared `summary`, but
+// `/rename` writes `name`) and with no parser case for `name`/`user_named` —
+// so the on-disk rename was silently dropped.
+//
+// These tests exercise the FULL chain end-to-end against the live watcher
+// running in the packaged tmax: write/modify a real workspace.yaml on disk,
+// wait for chokidar to fire, and verify the renderer's session list reflects
+// the change. They would have caught the original incomplete fix.
+//
+// We write into the user's REAL ~/.copilot/session-state dir with a clearly-
+// tagged fixture GUID (test-issue-2-...) and clean up in test teardown so
+// the user's normal sessions are untouched. Each test uses a fresh GUID
+// derived from Math.random() to keep parallel runs safe.
+
+const TEST_GUID_PREFIX = 'test-issue-2-fix';
+const SESSION_BASE = join(homedir(), '.copilot', 'session-state');
+
+function makeTestSession(): { guid: string; dir: string; cleanup: () => void } {
+  const guid = `${TEST_GUID_PREFIX}-${Math.random().toString(36).slice(2, 10)}`;
+  const dir = join(SESSION_BASE, guid);
+  mkdirSync(dir, { recursive: true });
+  return {
+    guid,
+    dir,
+    cleanup: () => {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    },
+  };
+}
+
+function writeWorkspaceYaml(dir: string, fields: Record<string, string | boolean>): void {
+  const lines = Object.entries(fields).map(([k, v]) => `${k}: ${v}`);
+  writeFileSync(join(dir, 'workspace.yaml'), lines.join('\n') + '\n');
+}
+
+function writeEventsJsonl(dir: string): void {
+  // Minimal events.jsonl with one user.message so messageCount > 0 (which the
+  // CopilotPanel sidebar filter requires to render the session at all). The
+  // exact event shape comes from looking at copilot-events-parser.ts and the
+  // real session files on disk.
+  const event = {
+    type: 'user.message',
+    timestamp: new Date().toISOString(),
+    user_content: 'fixture session for issue-2 tests',
+  };
+  writeFileSync(join(dir, 'events.jsonl'), JSON.stringify(event) + '\n');
+}
+
+test('Bug 1+2 — /rename via workspace.yaml propagates to renderer (the original fix path)', async () => {
+  const fixture = makeTestSession();
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+
+    // Wait for the initial async session scan to settle — the watcher's
+    // chokidar instance only fires 'add' for files created AFTER it
+    // reaches 'ready', and the renderer-visible signal that loadCopilotSessions
+    // has completed is copilotSqliteActive flipping true (or copilotSessions
+    // becoming non-empty for users with existing sessions on disk). Waiting
+    // for stability here avoids racing the watcher startup.
+    await window.waitForFunction(() => {
+      const s = (window as any).__terminalStore.getState();
+      return s.copilotSqliteActive === true || s.copilotSessions.length > 0;
+    }, null, { timeout: 15_000 });
+    // Extra grace — chokidar 'ready' fires up to ~1s after first scan completes.
+    await window.waitForTimeout(2_000);
+
+    // Step 1: seed initial workspace.yaml + events.jsonl on disk. The watcher
+    // is now fully ready, so this should fire 'add' events into the monitor.
+    writeWorkspaceYaml(fixture.dir, {
+      cwd: 'C:/projects/issue-2-fixture',
+      branch: 'main',
+      repository: 'fixture',
+      summary: 'BEFORE-RENAME',
+      user_named: false,
+    });
+    writeEventsJsonl(fixture.dir);
+
+    // Wait for the renderer to see our session.
+    await expect.poll(
+      async () => window.evaluate((guid) => {
+        const s = (window as any).__terminalStore.getState();
+        const ours = s.copilotSessions.find((x: any) => x.id === guid);
+        return ours?.summary ?? null;
+      }, fixture.guid),
+      { timeout: 15_000, intervals: [200, 500, 1000] },
+    ).toBe('BEFORE-RENAME');
+
+    // Step 2: simulate `/rename AFTER-RENAME` — the CLI rewrites the yaml
+    // with a new `name:` field and flips `user_named: true`. Note: it does
+    // NOT touch `summary:`. This was the exact field the original fix
+    // forgot about.
+    writeWorkspaceYaml(fixture.dir, {
+      cwd: 'C:/projects/issue-2-fixture',
+      branch: 'main',
+      repository: 'fixture',
+      summary: 'BEFORE-RENAME', // intentionally unchanged
+      name: 'AFTER-RENAME',
+      user_named: true,
+    });
+
+    // Wait for the change to round-trip through:
+    //   1. chokidar 'change' event on workspace.yaml
+    //   2. CopilotSessionWatcher.onEventsChanged routes it (Bug 1 fix)
+    //   3. CopilotSessionMonitor.refreshSession diff detects name/userNamed
+    //      change and fires onSessionUpdated (Bug 2 fix + this commit's diff
+    //      additions)
+    //   4. IPC push to renderer; store's updateCopilotSession replaces the
+    //      session in copilotSessions
+    //   5. CopilotPanel useMemo recomputes display name
+    //
+    // The post-fix parser sets workspace.summary = name when user_named=true,
+    // so the renderer's session.summary should change to "AFTER-RENAME".
+    await expect.poll(
+      async () => window.evaluate((guid) => {
+        const s = (window as any).__terminalStore.getState();
+        const ours = s.copilotSessions.find((x: any) => x.id === guid);
+        return ours?.summary ?? null;
+      }, fixture.guid),
+      { timeout: 15_000, intervals: [200, 500, 1000] },
+    ).toContain('AFTER-RENAME');
+  } finally {
+    fixture.cleanup();
+    await close();
+  }
+});
+
+test('Bug 1+2 — workspace.yaml without user_named keeps deriving name from summary (no regression)', async () => {
+  // Sanity: a workspace.yaml change that does NOT have user_named=true must
+  // continue to use the existing derive-from-summary path, not the new
+  // user-named override branch. This guards the parser's existing behaviour
+  // for sessions where `/rename` was never used.
+  const fixture = makeTestSession();
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await window.waitForFunction(() => {
+      const s = (window as any).__terminalStore.getState();
+      return s.copilotSqliteActive === true || s.copilotSessions.length > 0;
+    }, null, { timeout: 15_000 });
+    await window.waitForTimeout(2_000);
+
+    writeWorkspaceYaml(fixture.dir, {
+      cwd: 'C:/projects/issue-2-fixture-no-rename',
+      branch: 'main',
+      repository: 'fixture',
+      summary: 'normal-summary',
+      name: 'this-name-should-be-ignored',
+      user_named: false,
+    });
+    writeEventsJsonl(fixture.dir);
+
+    // Single poll for both presence and the expected summary value.
+    // Splitting waitForFunction(presence) + window.evaluate(read) is racy:
+    // autoArchiveStaleSessions periodically prunes sessions and may remove
+    // our short-lived fixture between the two awaits.
+    await expect.poll(
+      async () => window.evaluate((guid) => {
+        const s = (window as any).__terminalStore.getState();
+        const ours = s.copilotSessions.find((x: any) => x.id === guid);
+        return ours?.summary ?? null;
+      }, fixture.guid),
+      { timeout: 15_000, intervals: [200, 500, 1000] },
+    ).toBe('normal-summary');
+  } finally {
+    fixture.cleanup();
+    await close();
+  }
+});


### PR DESCRIPTION
Closes #2

## Problem

Three independent bugs caused rename actions to be **disconnected** across the AI Sessions sidebar, the tab title, and the Copilot CLI `/rename` command. Renaming in any one place did not propagate to the others.

## Fixes

### Commit `b86b24f` — original 3-fix attempt

| File | Change |
|------|--------|
| `src/main/copilot-session-watcher.ts` | Route `workspace.yaml` change events (was only routing `events.jsonl`) |
| `src/main/copilot-session-monitor.ts` | Compare `workspace.summary` in `refreshSession` diff |
| `src/renderer/components/CopilotPanel.tsx` | Simplified `handleFinishRename` + `useMemo` derivation from linked terminal `customTitle` (tab → sidebar sync) |
| `src/renderer/state/terminal-store.ts` | Add `firstCommandTitle: false` to `setSessionNameOverride` (TASK-88 regression guard) |

### Commit `3a0c1cb` — follow-up: actually make `/rename` work

Manual testing of `b86b24f` exposed two latent bugs **in the original fix itself**:

1. **Parser ignored `name` and `user_named` fields.** `parseWorkspace` switched on `cwd`/`branch`/`repository`/`summary` only, then *derived* `workspace.name` from those. Anything the CLI wrote to `name:` was thrown away on every parse.
2. **Diff guard compared the wrong field.** `refreshSession` watched `workspace.summary` — but `/rename` writes `name:` (and flips `user_named: true`), **never** `summary:`. Even with bug 1 fixed, the diff would not have detected `/rename` and `onSessionUpdated` would not have fired.

This commit:
- Adds parser cases for `name` and `user_named`
- Skips name-derivation when `user_named: true` and seeds `workspace.summary = workspace.name` so the renderer (which reads summary) shows the user's chosen name
- Extends the `refreshSession` diff to compare `workspace.name` and `workspace.userNamed`
- Adds `userNamed?: boolean` to `CopilotWorkspaceMetadata`

## Tests — 6/6 passing in ~1 min

### Renderer-side (`tests/e2e/issue-2-rename-sync.spec.ts`)
- **3a** — `setSessionNameOverride` writes title + 4 flags to all linked terminals; unlinked untouched
- **3b** — Sidebar useMemo derives display name from linked terminal `customTitle` (tab → sidebar)
- **3c** — `sessionNameOverrides` beats linked terminal customTitle (precedence)
- **3d** — `firstCommandTitle:false` guard against TASK-88 regression — **proven** by reverting the one-word change and watching the test fail

### Disk-watcher (`tests/e2e/issue-2-rename-watcher.spec.ts`)
Real disk-based e2e tests against the live watcher running in the packaged tmax — exercise the FULL chain end-to-end (disk → chokidar → watcher → monitor → IPC → store → renderer):

- **Bug 1+2** — `/rename` via `workspace.yaml` propagates to renderer. Seeds workspace.yaml on disk, modifies it to simulate `/rename`, asserts the renderer's `session.summary` updates within 15s. **Caught the original incomplete fix when run against b86b24f alone.**
- **Bug 1+2 no-regression** — workspace.yaml without `user_named` keeps deriving name from summary

## Run locally

```powershell
$env:FORGE_OUT_DIR = ""out-e2e""
npm run package
npx playwright test tests/e2e/issue-2-rename-sync.spec.ts tests/e2e/issue-2-rename-watcher.spec.ts
```

## Branch state

3 commits ahead of upstream `main`, 0 behind:
- `3a0c1cb` — fix(rename-sync): actually propagate /rename through workspace.yaml
- `5921489` — test(rename-sync): playwright coverage for issue #2 fix
- `b86b24f` — fix: sync rename between sidebar, tab, and Copilot /rename

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
