### PR TITLE
feat: centralised getEffectiveCwd() + provider helpers with stale session guard

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,7 +4,7 @@ import {
   DragOverlay,
   pointerWithin,
 } from '@dnd-kit/core';
-import { useTerminalStore } from './state/terminal-store';
+import { useTerminalStore, getEffectiveCwd, findSessionById, getSessionProvider } from './state/terminal-store';
 import { getTerminalEntry } from './terminal-registry';
 import { applyChromeFromTheme } from './utils/theme-presets';
 import type { CopilotSessionSummary } from '../shared/copilot-types';
@@ -145,6 +145,11 @@ const App: React.FC = () => {
 
     (window as any).__terminalStore = useTerminalStore;
     (window as any).__getTerminalEntry = getTerminalEntry;
+    // Exposed for e2e tests so specs can exercise the real helper from a
+    // browser context (where ESM/CJS require() is unavailable).
+    (window as any).__getEffectiveCwd = getEffectiveCwd;
+    (window as any).__findSessionById = findSessionById;
+    (window as any).__getSessionProvider = getSessionProvider;
 
     // Ctrl+wheel (Cmd+wheel on Mac): zoom the terminal font instead of letting
     // Chromium do its CSS page-zoom. preventDefault MUST happen before the

--- a/src/renderer/components/DiffReview.tsx
+++ b/src/renderer/components/DiffReview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
-import { useTerminalStore } from '../state/terminal-store';
+import { useTerminalStore, getEffectiveCwd } from '../state/terminal-store';
 import { tokenizeAnd, matchesAllTokens } from '../../shared/and-filter';
 import type {
   DiffMode,
@@ -404,21 +404,13 @@ const DiffReview: React.FC = () => {
   const diffReviewMode = useTerminalStore(s => s.diffReviewMode);
   const closeDiffReview = useTerminalStore(s => s.closeDiffReview);
   const setDiffReviewMode = useTerminalStore(s => s.setDiffReviewMode);
-  // Prefer the AI session's CWD when the terminal is linked to an active session.
-  // The CLI changes directory internally without emitting OSC sequences, so
-  // terminal.cwd (shell CWD) stays stale. The session monitor tracks the real
-  // working directory via workspace metadata. Falls back to shell CWD when no
-  // AI session is linked. See: https://github.com/yoziv/tmax/issues/3
-  const terminalCwd = useTerminalStore(s => {
-    const t = diffReviewTerminalId ? s.terminals.get(diffReviewTerminalId) : null;
-    if (!t) return '';
-    if (t.aiSessionId) {
-      const sess = s.copilotSessions.find(x => x.id === t.aiSessionId)
-                ?? s.claudeCodeSessions.find(x => x.id === t.aiSessionId);
-      if (sess?.cwd) return sess.cwd;
-    }
-    return t.cwd ?? '';
-  });
+  const terminalCwd = useTerminalStore(s =>
+    getEffectiveCwd(
+      diffReviewTerminalId ? s.terminals.get(diffReviewTerminalId) : undefined,
+      s.copilotSessions,
+      s.claudeCodeSessions,
+    )
+  );
   const agentLabel = useTerminalStore(s => {
     if (!diffReviewTerminalId) return 'Agent';
     const t = s.terminals.get(diffReviewTerminalId);

--- a/src/renderer/components/DiffReview.tsx
+++ b/src/renderer/components/DiffReview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
-import { useTerminalStore, getEffectiveCwd } from '../state/terminal-store';
+import { useTerminalStore, getEffectiveCwd, getSessionProvider } from '../state/terminal-store';
 import { tokenizeAnd, matchesAllTokens } from '../../shared/and-filter';
 import type {
   DiffMode,
@@ -416,10 +416,9 @@ const DiffReview: React.FC = () => {
     const t = s.terminals.get(diffReviewTerminalId);
     if (!t) return 'Agent';
     // Primary: check session lists via aiSessionId (authoritative)
-    if (t.aiSessionId) {
-      if (s.copilotSessions.some(x => x.id === t.aiSessionId)) return 'Copilot';
-      if (s.claudeCodeSessions.some(x => x.id === t.aiSessionId)) return 'Claude';
-    }
+    const provider = getSessionProvider(s.copilotSessions, s.claudeCodeSessions, t.aiSessionId);
+    if (provider === 'copilot') return 'Copilot';
+    if (provider === 'claude-code') return 'Claude';
     // Fallback: process/title heuristic (before session linking completes)
     const proc = (t.lastProcess ?? '').toLowerCase();
     const title = (t.title ?? '').toLowerCase();

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
-import { useTerminalStore } from '../state/terminal-store';
+import { useTerminalStore, findSessionById } from '../state/terminal-store';
 import { getLeafOrder } from '../state/terminal-store';
 import { formatKeyForPlatform, isDev } from '../utils/platform';
 import InputDialog from './InputDialog';
@@ -400,11 +400,7 @@ const StatusBar: React.FC = () => {
   // ai:true only appear when the focused pane is linked to an AI session.
   const focusedAiSession = useTerminalStore((s) => {
     if (!focused?.aiSessionId) return null;
-    return (
-      s.claudeCodeSessions.find((x) => x.id === focused.aiSessionId) ||
-      s.copilotSessions.find((x) => x.id === focused.aiSessionId) ||
-      null
-    );
+    return findSessionById(s.copilotSessions, s.claudeCodeSessions, focused.aiSessionId);
   });
   const TIPS: { text: string; ai?: boolean }[] = React.useMemo(() => [
     { text: 'Ctrl+U clears the input line in Claude Code / Copilot CLI (Ctrl+C interrupts the agent).', ai: true },
@@ -470,9 +466,7 @@ const StatusBar: React.FC = () => {
   const terminalListEntries = React.useMemo<TerminalListEntry[]>(() => {
     const findStatus = (aiSessionId: string | undefined): CopilotSessionStatus | null => {
       if (!aiSessionId) return null;
-      const found = copilotSessions.find((s: CopilotSessionSummary) => s.id === aiSessionId)
-        || claudeCodeSessions.find((s: CopilotSessionSummary) => s.id === aiSessionId);
-      return found ? found.status : null;
+      return findSessionById(copilotSessions, claudeCodeSessions, aiSessionId)?.status ?? null;
     };
     const out: TerminalListEntry[] = [];
     for (const [id, t] of terminals) {

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState, useEffect, useRef, useMemo } from 'react'
 import ReactDOM from 'react-dom';
 import { SortableContext, useSortable, horizontalListSortingStrategy, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useTerminalStore, TAB_COLORS } from '../state/terminal-store';
+import { useTerminalStore, TAB_COLORS, findSessionById } from '../state/terminal-store';
 import type { TerminalId } from '../state/types';
 import TabContextMenu, { type ContextMenuPosition } from './TabContextMenu';
 import { isMac } from '../utils/platform';
@@ -70,11 +70,7 @@ const Tab: React.FC<TabProps> = ({
   const aiSessionId = terminal?.aiSessionId;
   const aiStatus = useTerminalStore((s) => {
     if (!aiSessionId) return null;
-    const copilot = s.copilotSessions.find((x) => x.id === aiSessionId);
-    if (copilot) return copilot.status;
-    const claude = s.claudeCodeSessions.find((x) => x.id === aiSessionId);
-    if (claude) return claude.status;
-    return null;
+    return findSessionById(s.copilotSessions, s.claudeCodeSessions, aiSessionId)?.status ?? null;
   });
   const needsAttention = aiStatus === 'waitingForUser' || aiStatus === 'awaitingApproval';
   const isThinking = aiStatus === 'thinking' || aiStatus === 'executingTool';

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -4,7 +4,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
 import { SerializeAddon } from '@xterm/addon-serialize';
-import { useTerminalStore } from '../state/terminal-store';
+import { useTerminalStore, findSessionById, getSessionProvider } from '../state/terminal-store';
 import { registerTerminal, unregisterTerminal } from '../terminal-registry';
 import { saveTerminalBuffer, popTerminalBuffer } from '../terminal-buffer-cache';
 import { isMac, formatKeyForPlatform } from '../utils/platform';
@@ -2495,31 +2495,19 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
   );
   const latestPrompt = useTerminalStore((s) => {
     if (!aiSessionId) return undefined;
-    const cc = s.claudeCodeSessions.find((x) => x.id === aiSessionId);
-    if (cc?.latestPrompt) return cc.latestPrompt;
-    const cp = s.copilotSessions.find((x) => x.id === aiSessionId);
-    return cp?.latestPrompt;
+    return findSessionById(s.copilotSessions, s.claudeCodeSessions, aiSessionId)?.latestPrompt;
   });
   const latestPromptTime = useTerminalStore((s) => {
     if (!aiSessionId) return undefined;
-    const cc = s.claudeCodeSessions.find((x) => x.id === aiSessionId);
-    if (cc?.latestPromptTime) return cc.latestPromptTime;
-    const cp = s.copilotSessions.find((x) => x.id === aiSessionId);
-    return cp?.latestPromptTime;
+    return findSessionById(s.copilotSessions, s.claudeCodeSessions, aiSessionId)?.latestPromptTime;
   });
   const sessionStatus = useTerminalStore((s) => {
     if (!aiSessionId) return undefined;
-    const cc = s.claudeCodeSessions.find((x) => x.id === aiSessionId);
-    if (cc) return cc.status;
-    const cp = s.copilotSessions.find((x) => x.id === aiSessionId);
-    return cp?.status;
+    return findSessionById(s.copilotSessions, s.claudeCodeSessions, aiSessionId)?.status;
   });
-  const aiProvider = useTerminalStore((s): 'copilot' | 'claude-code' | undefined => {
-    if (!aiSessionId) return undefined;
-    if (s.copilotSessions.find((x) => x.id === aiSessionId)) return 'copilot';
-    if (s.claudeCodeSessions.find((x) => x.id === aiSessionId)) return 'claude-code';
-    return undefined;
-  });
+  const aiProvider = useTerminalStore((s): 'copilot' | 'claude-code' | undefined =>
+    getSessionProvider(s.copilotSessions, s.claudeCodeSessions, aiSessionId),
+  );
   // Force a re-render every 30s so the relative time stays fresh even when
   // nothing else in the session changes.
   const [, tickForClock] = useReducer((n: number) => n + 1, 0);

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -53,6 +53,23 @@ export function findSessionById(
 }
 
 /**
+ * Resolve which provider owns a given session ID. Returns the provider
+ * tag or undefined when no provider has a matching session. Pairs with
+ * {@link findSessionById} for sites that need only the provider, not
+ * the full session object.
+ */
+export function getSessionProvider(
+  copilotSessions: CopilotSessionSummary[],
+  claudeCodeSessions: CopilotSessionSummary[],
+  sessionId: string | undefined,
+): 'copilot' | 'claude-code' | undefined {
+  if (!sessionId) return undefined;
+  if (copilotSessions.some((s) => s.id === sessionId)) return 'copilot';
+  if (claudeCodeSessions.some((s) => s.id === sessionId)) return 'claude-code';
+  return undefined;
+}
+
+/**
  * Resolve the effective working directory for a terminal.
  * Prefers the linked AI session's CWD when the session is active (not idle),
  * falling back to the terminal's shell CWD otherwise. This avoids stale
@@ -84,14 +101,7 @@ function snapshotPaneForRestore(
   copilotSessions: CopilotSessionSummary[],
   claudeCodeSessions: CopilotSessionSummary[],
 ): ClosedPaneSnapshot {
-  let aiProvider: 'copilot' | 'claude-code' | undefined;
-  if (instance.aiSessionId) {
-    if (copilotSessions.some((s) => s.id === instance.aiSessionId)) {
-      aiProvider = 'copilot';
-    } else if (claudeCodeSessions.some((s) => s.id === instance.aiSessionId)) {
-      aiProvider = 'claude-code';
-    }
-  }
+  const aiProvider = getSessionProvider(copilotSessions, claudeCodeSessions, instance.aiSessionId);
   return {
     title: instance.title,
     customTitle: instance.customTitle,
@@ -3017,10 +3027,8 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       if (!t) return '';
       if (t.aiSessionId && config) {
         if (!validateSessionId(t.aiSessionId)) return '';
-        const isCopilot = copilotSessions.some((s) => s.id === t.aiSessionId);
-        if (isCopilot) return buildResumeCommand(config, 'copilot', t.aiSessionId);
-        const isClaude = claudeCodeSessions.some((s) => s.id === t.aiSessionId);
-        if (isClaude) return buildResumeCommand(config, 'claude-code', t.aiSessionId);
+        const provider = getSessionProvider(copilotSessions, claudeCodeSessions, t.aiSessionId);
+        if (provider) return buildResumeCommand(config, provider, t.aiSessionId);
       }
       return t.startupCommand || '';
     }
@@ -3989,8 +3997,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
         if (t.aiSessionId && id !== focusedTerminalId) continue;
         if (t.aiSessionId) {
           const { copilotSessions: cs, claudeCodeSessions: ccs } = get();
-          const prevSession = cs.find((s) => s.id === t.aiSessionId)
-            || ccs.find((s) => s.id === t.aiSessionId);
+          const prevSession = findSessionById(cs, ccs, t.aiSessionId);
           if (prevSession && prevSession.status !== 'idle') continue;
         }
         // TASK-154 guard: if the pane has a process-tree stamp, only
@@ -4512,15 +4519,8 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       let cmd = t.startupCommand;
       if (!cmd && t.aiSessionId) {
         if (!validateSessionId(t.aiSessionId)) continue;
-        const isCopilot = copilotSessions.some((s) => s.id === t.aiSessionId);
-        if (isCopilot) {
-          cmd = buildResumeCommand(config, 'copilot', t.aiSessionId);
-        } else {
-          const isClaude = claudeCodeSessions.some((s) => s.id === t.aiSessionId);
-          if (isClaude) {
-            cmd = buildResumeCommand(config, 'claude-code', t.aiSessionId);
-          }
-        }
+        const provider = getSessionProvider(copilotSessions, claudeCodeSessions, t.aiSessionId);
+        if (provider) cmd = buildResumeCommand(config, provider, t.aiSessionId);
       }
       if (cmd) {
         window.terminalAPI.writePty(id, cmd + '\r');

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -33,6 +33,46 @@ function validateSessionId(id: string): boolean {
 
 type SessionProvider = 'copilot' | 'claude-code';
 
+// ── Shared session/CWD helpers ─────────────────────────────────────
+// Centralizes the "find session by ID across both provider arrays" pattern
+// so callers don't hardcode provider-specific array names. When a third
+// provider is added, only these helpers need updating.
+
+/**
+ * Find a session by ID across all provider session lists.
+ * Returns the session summary or null if not found.
+ */
+export function findSessionById(
+  copilotSessions: CopilotSessionSummary[],
+  claudeCodeSessions: CopilotSessionSummary[],
+  sessionId: string,
+): CopilotSessionSummary | null {
+  return copilotSessions.find(x => x.id === sessionId)
+      ?? claudeCodeSessions.find(x => x.id === sessionId)
+      ?? null;
+}
+
+/**
+ * Resolve the effective working directory for a terminal.
+ * Prefers the linked AI session's CWD when the session is active (not idle),
+ * falling back to the terminal's shell CWD otherwise. This avoids stale
+ * session CWDs overriding the shell's real directory after the CLI exits.
+ *
+ * See: https://github.com/yoziv/tmax/issues/3
+ */
+export function getEffectiveCwd(
+  terminal: TerminalInstance | undefined,
+  copilotSessions: CopilotSessionSummary[],
+  claudeCodeSessions: CopilotSessionSummary[],
+): string {
+  if (!terminal) return '';
+  if (terminal.aiSessionId) {
+    const sess = findSessionById(copilotSessions, claudeCodeSessions, terminal.aiSessionId);
+    if (sess?.cwd && sess.status !== 'idle') return sess.cwd;
+  }
+  return terminal.cwd ?? '';
+}
+
 /**
  * Capture the bits of a TerminalInstance that the undo-close stack
  * needs to recreate an equivalent pane (TASK-112). Provider for AI

--- a/tests/e2e/effective-cwd-helper.spec.ts
+++ b/tests/e2e/effective-cwd-helper.spec.ts
@@ -52,30 +52,20 @@ function injectTerminal(window: any, opts: { termId: string; sessId?: string; cw
 
 function evalEffectiveCwd(window: any, termId: string) {
   return window.evaluate(({ termId }: any) => {
-    // Import the helper from the store module
-    const { getEffectiveCwd } = require('../src/renderer/state/terminal-store');
-    if (typeof getEffectiveCwd === 'function') {
-      const s = (window as any).__terminalStore.getState();
-      const t = s.terminals.get(termId);
-      return getEffectiveCwd(t, s.copilotSessions, s.claudeCodeSessions);
-    }
-    // Fallback: replicate the logic inline (packaged app may not have require)
-    const s = (window as any).__terminalStore.getState();
+    const w = window as any;
+    const s = w.__terminalStore.getState();
     const t = s.terminals.get(termId);
-    if (!t) return '';
-    if (t.aiSessionId) {
-      const sess = [...(s.copilotSessions || []), ...(s.claudeCodeSessions || [])]
-        .find((x: any) => x.id === t.aiSessionId);
-      if (sess?.cwd && sess.status !== 'idle') return sess.cwd;
-    }
-    return t.cwd ?? '';
+    // Helper is exposed on window from src/renderer/App.tsx so e2e specs
+    // can exercise the real implementation without a CJS require() (which
+    // is unavailable in a sandboxed browser context).
+    return w.__getEffectiveCwd(t, s.copilotSessions, s.claudeCodeSessions);
   }, { termId });
 }
 
 test('active AI session CWD preferred over shell CWD', async () => {
   const { window, close } = await launchTmax();
   try {
-    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await window.waitForFunction(() => !!(window as any).__terminalStore && !!(window as any).__getEffectiveCwd, null, { timeout: 15_000 });
 
     await injectTerminal(window, { termId: TERMINAL_ID, sessId: SESSION_ID, cwd: SHELL_CWD });
     await window.evaluate(({ session }: any) => {
@@ -100,7 +90,7 @@ test('active AI session CWD preferred over shell CWD', async () => {
 test('idle AI session CWD NOT used — falls back to shell CWD', async () => {
   const { window, close } = await launchTmax();
   try {
-    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await window.waitForFunction(() => !!(window as any).__terminalStore && !!(window as any).__getEffectiveCwd, null, { timeout: 15_000 });
 
     await injectTerminal(window, { termId: TERMINAL_ID, sessId: SESSION_ID, cwd: SHELL_CWD });
     await window.evaluate(({ session }: any) => {
@@ -120,7 +110,7 @@ test('idle AI session CWD NOT used — falls back to shell CWD', async () => {
 test('no AI session — uses shell CWD', async () => {
   const { window, close } = await launchTmax();
   try {
-    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await window.waitForFunction(() => !!(window as any).__terminalStore && !!(window as any).__getEffectiveCwd, null, { timeout: 15_000 });
 
     await injectTerminal(window, { termId: 'plain-terminal', cwd: SHELL_CWD });
 
@@ -134,7 +124,7 @@ test('no AI session — uses shell CWD', async () => {
 test('stale aiSessionId (session removed) — falls back to shell CWD', async () => {
   const { window, close } = await launchTmax();
   try {
-    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+    await window.waitForFunction(() => !!(window as any).__terminalStore && !!(window as any).__getEffectiveCwd, null, { timeout: 15_000 });
 
     // Terminal linked to a session that doesn't exist in the arrays
     await injectTerminal(window, { termId: TERMINAL_ID, sessId: 'nonexistent-session', cwd: SHELL_CWD });

--- a/tests/e2e/effective-cwd-helper.spec.ts
+++ b/tests/e2e/effective-cwd-helper.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+import { launchTmax } from './fixtures/launch';
+import type { CopilotSessionSummary } from '../../src/shared/copilot-types';
+
+// Tests for getEffectiveCwd() helper and DiffReview CWD resolution.
+// Covers: https://github.com/yoziv/tmax/issues/3 + follow-ups
+//
+// Follow-up 1: Stale session guard — only prefer AI CWD when session is active
+// Follow-up 2: Centralized helper — getEffectiveCwd() used by all consumers
+
+const SESSION_ID = 'effective-cwd-test-session';
+const TERMINAL_ID = 'effective-cwd-test-terminal';
+const SHELL_CWD = 'C:\\Users';
+const AI_SESSION_CWD = 'C:\\Users\\yoziv\\source\\repos\\MyProject';
+
+function makeSession(overrides: Partial<CopilotSessionSummary> = {}): CopilotSessionSummary {
+  return {
+    id: SESSION_ID,
+    provider: 'copilot',
+    status: 'thinking',
+    cwd: AI_SESSION_CWD,
+    branch: 'main',
+    repository: 'MyProject',
+    summary: 'Test session',
+    messageCount: 1,
+    toolCallCount: 0,
+    lastActivityTime: Date.now(),
+    ...overrides,
+  };
+}
+
+function injectTerminal(window: any, opts: { termId: string; sessId?: string; cwd: string }) {
+  return window.evaluate(({ termId, sessId, cwd }: any) => {
+    const store = (window as any).__terminalStore.getState();
+    const newTerminals = new Map(store.terminals);
+    newTerminals.set(termId, {
+      id: termId,
+      title: 'test-pane',
+      customTitle: true,
+      shellProfileId: 'pwsh',
+      cwd,
+      mode: 'tiled',
+      pid: 9999,
+      lastProcess: '',
+      startupCommand: '',
+      aiSessionId: sessId,
+      aiAutoTitle: true,
+    });
+    (window as any).__terminalStore.setState({ terminals: newTerminals });
+  }, opts);
+}
+
+function evalEffectiveCwd(window: any, termId: string) {
+  return window.evaluate(({ termId }: any) => {
+    // Import the helper from the store module
+    const { getEffectiveCwd } = require('../src/renderer/state/terminal-store');
+    if (typeof getEffectiveCwd === 'function') {
+      const s = (window as any).__terminalStore.getState();
+      const t = s.terminals.get(termId);
+      return getEffectiveCwd(t, s.copilotSessions, s.claudeCodeSessions);
+    }
+    // Fallback: replicate the logic inline (packaged app may not have require)
+    const s = (window as any).__terminalStore.getState();
+    const t = s.terminals.get(termId);
+    if (!t) return '';
+    if (t.aiSessionId) {
+      const sess = [...(s.copilotSessions || []), ...(s.claudeCodeSessions || [])]
+        .find((x: any) => x.id === t.aiSessionId);
+      if (sess?.cwd && sess.status !== 'idle') return sess.cwd;
+    }
+    return t.cwd ?? '';
+  }, { termId });
+}
+
+test('active AI session CWD preferred over shell CWD', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+
+    await injectTerminal(window, { termId: TERMINAL_ID, sessId: SESSION_ID, cwd: SHELL_CWD });
+    await window.evaluate(({ session }: any) => {
+      (window as any).__terminalStore.setState({
+        copilotSessions: [session],
+      });
+    }, { session: makeSession({ status: 'thinking' }) });
+
+    const cwd = await evalEffectiveCwd(window, TERMINAL_ID);
+    expect(cwd).toBe(AI_SESSION_CWD);
+
+    // Shell CWD should be untouched
+    const shellCwd = await window.evaluate(({ termId }: any) => {
+      return (window as any).__terminalStore.getState().terminals.get(termId)?.cwd;
+    }, { termId: TERMINAL_ID });
+    expect(shellCwd).toBe(SHELL_CWD);
+  } finally {
+    await close();
+  }
+});
+
+test('idle AI session CWD NOT used — falls back to shell CWD', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+
+    await injectTerminal(window, { termId: TERMINAL_ID, sessId: SESSION_ID, cwd: SHELL_CWD });
+    await window.evaluate(({ session }: any) => {
+      (window as any).__terminalStore.setState({
+        copilotSessions: [session],
+      });
+    }, { session: makeSession({ status: 'idle' }) });
+
+    const cwd = await evalEffectiveCwd(window, TERMINAL_ID);
+    // Should fall back to shell CWD because session is idle
+    expect(cwd).toBe(SHELL_CWD);
+  } finally {
+    await close();
+  }
+});
+
+test('no AI session — uses shell CWD', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+
+    await injectTerminal(window, { termId: 'plain-terminal', cwd: SHELL_CWD });
+
+    const cwd = await evalEffectiveCwd(window, 'plain-terminal');
+    expect(cwd).toBe(SHELL_CWD);
+  } finally {
+    await close();
+  }
+});
+
+test('stale aiSessionId (session removed) — falls back to shell CWD', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForFunction(() => !!(window as any).__terminalStore, null, { timeout: 15_000 });
+
+    // Terminal linked to a session that doesn't exist in the arrays
+    await injectTerminal(window, { termId: TERMINAL_ID, sessId: 'nonexistent-session', cwd: SHELL_CWD });
+
+    const cwd = await evalEffectiveCwd(window, TERMINAL_ID);
+    expect(cwd).toBe(SHELL_CWD);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up to #112 — addresses both pieces of @InbarR's review feedback on the original draft, now that #112 has merged.

### 1. Stale session guard (unchanged from prior revision)

`getEffectiveCwd()` only prefers the AI session's CWD when the session is **active** (`status !== 'idle'`). After the CLI exits and the session goes idle, the helper falls back to the shell's CWD — preventing the diff panel from showing the wrong repo.

### 2. Centralised helpers (now actually applied across the codebase)

Three exported helpers live in `src/renderer/state/terminal-store.ts`:

- **`findSessionById(copilotSessions, claudeCodeSessions, id)`** — replaces the duplicated `cs.find(...) ?? ccs.find(...)` pattern.
- **`getSessionProvider(copilotSessions, claudeCodeSessions, id)`** — returns `'copilot' \| 'claude-code' \| undefined` for sites that only need the provider tag (replaces `.some()` duplicates).
- **`getEffectiveCwd(terminal, copilotSessions, claudeCodeSessions)`** — single source of truth for `where is this terminal working?`

When a third AI provider is added, only these helpers need updating.

### 3. e2e test no longer relies on `require()` in the renderer

The previous spec used `require('../src/renderer/state/terminal-store')` inside `window.evaluate()`. Electron's renderer is a sandboxed browser context with no CommonJS `require`, so the call threw before the `typeof` fallback could run and the test silently failed on CI.

`App.tsx` now exposes `__getEffectiveCwd`, `__findSessionById`, and `__getSessionProvider` on `window` alongside `__terminalStore`, and the spec calls the real helpers directly. The inline fallback is gone — the test now actually exercises production code.

## Changes

| File | Change |
|------|--------|
| `src/renderer/state/terminal-store.ts` | Added `findSessionById`, `getSessionProvider`, `getEffectiveCwd`; migrated 4 internal sites |
| `src/renderer/App.tsx` | Exposed the three helpers on `window` for e2e |
| `src/renderer/components/DiffReview.tsx` | Uses `getEffectiveCwd` + `getSessionProvider` |
| `src/renderer/components/StatusBar.tsx` | 2 sites migrated to `findSessionById` |
| `src/renderer/components/TabBar.tsx` | `aiStatus` selector migrated |
| `src/renderer/components/TerminalPanel.tsx` | 4 selectors migrated (`latestPrompt`, `latestPromptTime`, `sessionStatus`, `aiProvider`) |
| `tests/e2e/effective-cwd-helper.spec.ts` | Drops `require()` + inline fallback; calls the real helper via `window` |

Net **-28 lines** across renderer code, no behaviour change for the migrated sites (IDs are unique across the provider arrays, so the lookup-order swap is semantically equivalent).

## Test coverage

| Scenario | Expected CWD | Test |
|----------|-------------|------|
| Active AI session linked | AI session CWD | ✅ |
| Idle AI session linked (stale) | Shell CWD (fallback) | ✅ |
| No AI session linked | Shell CWD | ✅ |
| Stale `aiSessionId` (session removed) | Shell CWD (fallback) | ✅ |

## Dependencies

Now rebased on top of merged #112. No outstanding chain.