### PR TITLE
feat: AI-generated 1-line summary for Copilot session tabs

### DIFF
--- a/src/main/config-store.ts
+++ b/src/main/config-store.ts
@@ -1,4 +1,6 @@
 import Store from 'electron-store';
+import type { PaneSummaryConfig } from '../shared/pane-summary-types';
+import { DEFAULT_PANE_SUMMARY_CONFIG } from '../shared/pane-summary-types';
 
 export interface ShellProfile {
   id: string;
@@ -109,6 +111,14 @@ export interface AppConfig {
    * ('alpha'). (TASK-135)
    */
   aiGroupByRepoOrder?: 'activity' | 'alpha';
+  /**
+   * AI-distilled 1-line pane summary feature (Task pane-summary). When
+   * `enabled` (default true), tmax spawns a sandboxed `copilot -p` per
+   * AI pane after `delayMs` and ≥3 user turns, and surfaces the result
+   * on hover of the tab/pane title. v1 = Copilot only; Claude panes
+   * report `unavailable`. The result is in-memory only, not persisted.
+   */
+  paneSummary?: PaneSummaryConfig;
 }
 
 function findPwsh(): string | null {
@@ -266,6 +276,7 @@ export const defaultConfig: AppConfig = {
   notificationExcludeStrings: [],
   aiShimmerEnabled: true,
   aiSessionLoadLimit: 314,
+  paneSummary: DEFAULT_PANE_SUMMARY_CONFIG,
 };
 
 export class ConfigStore {

--- a/src/main/copilot-session-monitor.ts
+++ b/src/main/copilot-session-monitor.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import { parseSessionEvents, clearParserCache, extractCopilotPrompts } from './copilot-events-parser';
 import { CopilotSessionDB, sessionRowToSummary } from './copilot-session-db';
 import { tokenizeAnd, matchesAllTokens } from '../shared/and-filter';
+import { SUMMARIZER_SESSION_NAME_PREFIX } from '../shared/pane-summary-types';
 import type {
   CopilotSession,
   CopilotSessionSummary,
@@ -50,6 +51,13 @@ export class CopilotSessionMonitor {
     return this.basePath;
   }
 
+  /** Returns true when a session row from SQLite or filesystem belongs to
+   *  the pane-summary feature's sandboxed summarizer spawn. Filtered out
+   *  of all UI surfaces. See src/main/pane-summary-service.ts. */
+  private isSummarizerSessionRow(row: { summary?: string }): boolean {
+    return !!row.summary && row.summary.startsWith(SUMMARIZER_SESSION_NAME_PREFIX);
+  }
+
   async scanSessions(limit = 314): Promise<CopilotSessionSummary[]> {
     // Try SQLite first (9-15x faster than filesystem scan)
     if (this.dbAvailable === null) {
@@ -89,6 +97,10 @@ export class CopilotSessionMonitor {
     const currentIds = new Set<string>();
 
     for (const row of sessionRows) {
+      // Skip our own summarizer-spawned sessions (Task pane-summary).
+      // They appear with `summary: tmax-summarizer:<uuid>` because the
+      // CLI mirrors `-n` into the DB summary field.
+      if (this.isSummarizerSessionRow(row)) continue;
       currentIds.add(row.id);
       const turnStats = turnStatsMap.get(row.id);
       const summary = sessionRowToSummary(row, turnStats);
@@ -206,6 +218,11 @@ export class CopilotSessionMonitor {
       const session = this.loadSession(sessionId, sessionDir);
 
       if (session) {
+        // Skip our own summarizer-spawned sessions (Task pane-summary).
+        if (session.workspace?.name?.startsWith(SUMMARIZER_SESSION_NAME_PREFIX)
+            || session.workspace?.summary?.startsWith(SUMMARIZER_SESSION_NAME_PREFIX)) {
+          continue;
+        }
         this.sessions.set(sessionId, session);
         const summary = this.toSummary(session);
         summaries.push(summary);
@@ -295,6 +312,7 @@ export class CopilotSessionMonitor {
 
         const results: CopilotSessionSummary[] = [];
         for (const row of searchRows) {
+          if (this.isSummarizerSessionRow(row)) continue;
           const turnStats = turnStatsMap?.get(row.id);
           const summary = sessionRowToSummary(row, turnStats);
 
@@ -394,6 +412,11 @@ export class CopilotSessionMonitor {
     }
     const session = this.loadSession(sessionId, sessionDir);
     if (session) {
+      // Skip our own summarizer sessions (Task pane-summary).
+      if (session.workspace?.name?.startsWith(SUMMARIZER_SESSION_NAME_PREFIX)
+          || session.workspace?.summary?.startsWith(SUMMARIZER_SESSION_NAME_PREFIX)) {
+        return;
+      }
       this.sessions.set(sessionId, session);
       this.callbacks.onSessionAdded?.(this.toSummary(session));
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,7 @@ import { KeybindingsFile } from './keybindings-file';
 import { IPC } from '../shared/ipc-channels';
 import { CopilotSessionMonitor } from './copilot-session-monitor';
 import { CopilotSessionWatcher } from './copilot-session-watcher';
+import { PaneSummaryService } from './pane-summary-service';
 import { notifyCopilotSession, clearNotificationCooldowns, setAiSessionNotificationsEnabled, setNotificationClickHandler, setSessionNameOverrides, setNotificationExcludeStrings } from './copilot-notification';
 import { ClaudeCodeSessionMonitor } from './claude-code-session-monitor';
 import { ClaudeCodeSessionWatcher } from './claude-code-session-watcher';
@@ -133,6 +134,7 @@ let configStore: ConfigStore | null = null;
 let keybindingsFile: KeybindingsFile | null = null;
 let copilotMonitor: CopilotSessionMonitor | null = null;
 let copilotWatcher: CopilotSessionWatcher | null = null;
+let paneSummaryService: PaneSummaryService | null = null;
 let claudeCodeMonitor: ClaudeCodeSessionMonitor | null = null;
 let claudeCodeWatcher: ClaudeCodeSessionWatcher | null = null;
 let wslSessionManager: WslSessionManager | null = null;
@@ -618,6 +620,29 @@ function registerIpcHandlers(): void {
     const pid = ptyManager?.getPid(id);
     if (typeof pid !== 'number') return [];
     return await getDescendantNames(pid);
+  });
+
+  // ── Pane summary (Task pane-summary). Routes renderer requests to
+  // the PaneSummaryService (lazily instantiated once the copilot monitor
+  // is up). Falls back to an `unavailable` error if the service couldn't
+  // be created (e.g. monitor never initialised).
+  ipcMain.on(IPC.PANE_SUMMARY_REQUEST, (event, req: import('../shared/pane-summary-types').PaneSummaryRequest) => {
+    diagLog('paneSummary.request', {
+      terminalId: sanitize(req?.terminalId),
+      provider: req?.provider,
+      force: !!req?.force,
+    });
+    if (!paneSummaryService) {
+      event.sender.send(IPC.PANE_SUMMARY_ERROR, {
+        terminalId: req.terminalId,
+        sessionId: req.sessionId,
+        provider: req.provider,
+        message: 'pane summary service not initialised',
+        unavailable: true,
+      });
+      return;
+    }
+    paneSummaryService.request(req, event.sender);
   });
 
   ipcMain.on(IPC.DIAG_LOG, (_event, event: string, data?: Record<string, unknown>) => {
@@ -1236,6 +1261,12 @@ function registerIpcHandlers(): void {
 function setupCopilotMonitor(): void {
   copilotMonitor = new CopilotSessionMonitor();
 
+  // Lazily wire pane-summary service now that the monitor exists.
+  paneSummaryService = new PaneSummaryService({
+    monitor: copilotMonitor,
+    config: () => configStore?.get('paneSummary'),
+  });
+
   copilotMonitor.setCallbacks({
     onSessionUpdated(session) {
       mainWindow?.webContents.send(IPC.COPILOT_SESSION_UPDATED, session);
@@ -1546,6 +1577,8 @@ app.on('window-all-closed', async () => {
   sessionFileWatcher = null;
   await copilotWatcher?.stop();
   copilotMonitor?.dispose();
+  paneSummaryService?.dispose();
+  paneSummaryService = null;
   await claudeCodeWatcher?.stop();
   claudeCodeMonitor?.dispose();
   await wslSessionManager?.stop();

--- a/src/main/pane-summary-service.ts
+++ b/src/main/pane-summary-service.ts
@@ -1,0 +1,776 @@
+// Pane summary service — Task pane-summary (T2)
+//
+// Spawns a sandboxed, non-interactive `copilot -p` child process to
+// distill a 1-sentence "what is the user doing in this pane" summary
+// from a Copilot AI session's recent user prompts.
+//
+// Design constraints (validated by Task 0 spike on 2026-05-20):
+//   • `--available-tools` ALONE does NOT sandbox. We must use the
+//     `--deny-tool 'shell(*)' --deny-tool 'write' --excluded-tools …`
+//     trio. Verified empirically that this blocks file reads.
+//   • Every `copilot -p` invocation creates a new session dir in
+//     ~/.copilot/session-state/<uuid>/. We tag ours with
+//     `-n "tmax-summarizer:<uuid>"` AND best-effort delete the dir
+//     after the spawn completes; the session monitor also filters by
+//     this prefix as a belt-and-braces.
+//   • `--effort medium` produces high-quality output in ~12s on the
+//     test corpus. We set a 60s timeout and one retry.
+//   • Prompt feeding: we send ONLY the user's own recent prompts
+//     (not assistant transcript) on stdin to dramatically reduce
+//     the prompt-injection surface area. The system prompt prefix
+//     instructs the model to use no tools.
+//   • De-dup is session-keyed (provider+sessionId). Two panes pointing
+//     at one session share one in-flight job; the same result fans
+//     out to both terminals.
+//   • Concurrency cap = 2 to avoid pegging the CPU on a multi-pane
+//     workspace; further requests queue.
+//   • In-memory cache keyed by {provider, sessionId, transcriptVersion}
+//     — short-circuits identical requests for the same transcript.
+
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { IPC } from '../shared/ipc-channels';
+import {
+  SUMMARIZER_SESSION_NAME_PREFIX,
+  buildTranscriptVersion,
+  type PaneSummaryRequest,
+  type PaneSummaryResult,
+  type PaneSummaryError,
+  type PaneSummaryConfig,
+} from '../shared/pane-summary-types';
+import type { CopilotSessionMonitor } from './copilot-session-monitor';
+import type { CopilotSession } from '../shared/copilot-types';
+import { extractCopilotPrompts } from './copilot-events-parser';
+import { diagLog, sanitize } from './diag-logger';
+
+// ── Tunables ───────────────────────────────────────────────────────
+const SPAWN_TIMEOUT_MS = 60_000;
+const MAX_RETRIES = 1;
+const MAX_CONCURRENCY = 2;
+const MAX_PROMPTS_IN_TRANSCRIPT = 6;
+const MAX_PROMPT_CHARS = 400;
+const MAX_OUTPUT_CHARS = 4_000;          // hard cap on raw stdout we accept
+const CACHE_TTL_MS = 60 * 60 * 1000;     // 1h — purely a memory cap; refreshed by transcriptVersion
+
+const SYSTEM_PROMPT =
+  'You are a passive summarizer. Do not use any tools. ' +
+  'Reply with one short sentence (12 words max) describing what the user is working on. ' +
+  'No preamble, no quotes, no markdown.';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+interface InFlightJob {
+  provider: 'copilot' | 'claude-code';
+  sessionId: string;
+  transcriptVersion: string;
+  promise: Promise<{ text: string } | { error: string; unavailable?: boolean }>;
+  /** terminal ids subscribed to this job's result */
+  subscribers: Set<string>;
+  /** for retry tracking */
+  attempts: number;
+  /** Set true when a newer job for the same session has superseded
+   *  this one. Stale jobs still complete (they're already spawned) but
+   *  must not write to the cache or notify subscribers. */
+  stale: boolean;
+}
+
+interface CacheEntry {
+  text: string;
+  generatedAt: number;
+  transcriptVersion: string;
+}
+
+interface QueuedRequest {
+  req: PaneSummaryRequest;
+  sender: Electron.WebContents;
+  enqueuedAt: number;
+}
+
+const MAX_QUEUE_DEPTH = 64;
+
+export interface PaneSummaryServiceDeps {
+  monitor: CopilotSessionMonitor;
+  /** optional: override executable resolution (tests). */
+  resolveExecutable?: () => string;
+  config?: () => PaneSummaryConfig | undefined;
+}
+
+// ── Output validation ──────────────────────────────────────────────
+
+const MEANINGLESS = [
+  /^session in progress\.?$/i,
+  /^working on (a|the )?session\.?$/i,
+  /^(no|n\/a|nothing)\.?$/i,
+  /^summary unavailable\.?$/i,
+  /^the user is/i,  // the prompt explicitly forbids "The user is …"; reject as low quality
+];
+
+function isMeaninglessSummary(text: string): boolean {
+  const stripped = text.replace(/[.!?]+$/, '').trim();
+  if (stripped.length < 6) return true;
+  return MEANINGLESS.some((re) => re.test(stripped));
+}
+
+/** Best-effort sanitization of model output into a single short sentence.
+ *  Returns null when output should be rejected (caller will surface a
+ *  validator error and retain any prior summary). */
+export function validateAndCleanSummary(raw: string): string | null {
+  if (!raw) return null;
+  let text = raw.slice(0, MAX_OUTPUT_CHARS);
+
+  // Strip code fences and JSON wrappers the model occasionally adds even
+  // when told not to.
+  text = text.replace(/^```[\w]*\s*/m, '').replace(/```\s*$/m, '');
+  // Take first non-empty line.
+  const firstLine = text.split(/\r?\n/).map((l) => l.trim()).find((l) => l.length > 0) ?? '';
+  text = firstLine;
+
+  // Strip surrounding quotes (single, double, smart).
+  text = text.replace(/^[\s"'“”‘’`]+/, '').replace(/[\s"'“”‘’`]+$/, '');
+  // Strip leading "Summary:" / "TL;DR:" / "Answer:" preambles.
+  text = text.replace(/^(summary|tl;dr|answer|response|result)\s*[:\-—]\s*/i, '');
+  // Collapse interior whitespace.
+  text = text.replace(/\s+/g, ' ').trim();
+
+  // Hard caps.
+  const words = text.split(/\s+/);
+  if (words.length > 25) text = words.slice(0, 25).join(' ');
+  if (text.length > 180) text = text.slice(0, 180).trim();
+
+  if (text.length < 6) return null;
+  if (isMeaninglessSummary(text)) return null;
+
+  // Ensure terminal punctuation for readability.
+  if (!/[.!?]$/.test(text)) text += '.';
+
+  return text;
+}
+
+// ── Service ────────────────────────────────────────────────────────
+
+export class PaneSummaryService {
+  private readonly deps: PaneSummaryServiceDeps;
+  private readonly cache = new Map<string, CacheEntry>(); // key = provider:sessionId
+  private readonly inFlight = new Map<string, InFlightJob>(); // key = provider:sessionId
+  private readonly queue: QueuedRequest[] = [];
+  private activeCount = 0;
+  private disposed = false;
+
+  constructor(deps: PaneSummaryServiceDeps) {
+    this.deps = deps;
+  }
+
+  /** Renderer entry point. Fire-and-forget; results arrive via IPC. */
+  request(req: PaneSummaryRequest, sender: Electron.WebContents): void {
+    if (this.disposed) return;
+    const cfg = this.deps.config?.();
+    if (cfg && cfg.enabled === false) {
+      this.emitError(sender, {
+        terminalId: req.terminalId,
+        sessionId: req.sessionId,
+        provider: req.provider,
+        message: 'pane summary disabled in settings',
+        unavailable: true,
+      });
+      return;
+    }
+
+    // v1: Claude not supported.
+    if (req.provider !== 'copilot') {
+      this.emitError(sender, {
+        terminalId: req.terminalId,
+        sessionId: req.sessionId,
+        provider: req.provider,
+        message: 'pane summary v1 supports Copilot only',
+        unavailable: true,
+      });
+      return;
+    }
+
+    void this.handleRequest(req, sender);
+  }
+
+  private async handleRequest(req: PaneSummaryRequest, sender: Electron.WebContents): Promise<void> {
+    const session = this.deps.monitor.getSession(req.sessionId);
+
+    if (!session) {
+      this.emitError(sender, {
+        terminalId: req.terminalId,
+        sessionId: req.sessionId,
+        provider: req.provider,
+        message: 'AI session not loaded',
+      });
+      return;
+    }
+
+    const transcriptVersion = buildTranscriptVersion(session.messageCount, session.latestPromptTime);
+    const cacheKey = `${req.provider}:${req.sessionId}`;
+
+    // Cache hit (and not forced) → emit existing result.
+    if (!req.force) {
+      const cached = this.cache.get(cacheKey);
+      if (cached && cached.transcriptVersion === transcriptVersion) {
+        this.emitResult(sender, {
+          terminalId: req.terminalId,
+          sessionId: req.sessionId,
+          provider: req.provider,
+          transcriptVersion,
+          text: cached.text,
+          generatedAt: cached.generatedAt,
+        });
+        return;
+      }
+    }
+
+    // Dedup: same {provider, sessionId, transcriptVersion} already in flight?
+    const inFlight = this.inFlight.get(cacheKey);
+    if (inFlight && inFlight.transcriptVersion === transcriptVersion) {
+      inFlight.subscribers.add(req.terminalId);
+      // Subscribe this terminal to the existing promise too.
+      void inFlight.promise.then((outcome) => {
+        if (inFlight.stale) return;
+        if (!inFlight.subscribers.has(req.terminalId)) return;
+        if ('text' in outcome) {
+          this.emitResult(sender, {
+            terminalId: req.terminalId,
+            sessionId: req.sessionId,
+            provider: req.provider,
+            transcriptVersion,
+            text: outcome.text,
+            generatedAt: this.cache.get(cacheKey)?.generatedAt ?? Date.now(),
+          });
+        } else {
+          this.emitError(sender, {
+            terminalId: req.terminalId,
+            sessionId: req.sessionId,
+            provider: req.provider,
+            message: outcome.error,
+            unavailable: outcome.unavailable,
+          });
+        }
+      });
+      return;
+    }
+
+    // An older job for this session is in flight but its transcriptVersion
+    // is stale (typically a force=true refresh after new messages arrived).
+    // Mark it stale so when it finally completes it neither writes to the
+    // cache nor notifies subscribers — they're about to get a fresher result.
+    if (inFlight && inFlight.transcriptVersion !== transcriptVersion) {
+      inFlight.stale = true;
+    }
+
+    // Concurrency gate.
+    if (this.activeCount >= MAX_CONCURRENCY) {
+      // Coalesce: if a queued entry already exists for this terminalId,
+      // replace it with the newer request rather than appending. Prevents
+      // queue bloat from impatient menu-refresh clicks.
+      const existingIdx = this.queue.findIndex((q) => q.req.terminalId === req.terminalId);
+      if (existingIdx >= 0) {
+        this.queue[existingIdx] = { req: { ...req }, sender, enqueuedAt: Date.now() };
+      } else if (this.queue.length >= MAX_QUEUE_DEPTH) {
+        // Hard cap — fail loudly rather than leak memory.
+        this.emitError(sender, {
+          terminalId: req.terminalId,
+          sessionId: req.sessionId,
+          provider: req.provider,
+          message: 'summary queue full; try again shortly',
+        });
+        return;
+      } else {
+        this.queue.push({ req: { ...req }, sender, enqueuedAt: Date.now() });
+      }
+      diagLog('paneSummary.queued', { sessionId: sanitize(req.sessionId), queueDepth: this.queue.length });
+      return;
+    }
+
+    await this.runJob(req, session, transcriptVersion, sender);
+  }
+
+  /** Look up a session in the monitor by id. Kept as a stub so tests can
+   *  swap the monitor implementation without honouring the real shape. */
+  private findSessionInMonitor(_sessionId: string): CopilotSession | undefined {
+    return undefined;
+  }
+
+  private async runJob(
+    req: PaneSummaryRequest,
+    session: CopilotSession,
+    transcriptVersion: string,
+    sender: Electron.WebContents,
+  ): Promise<void> {
+    const cacheKey = `${req.provider}:${req.sessionId}`;
+    this.activeCount++;
+
+    const job: InFlightJob = {
+      provider: req.provider,
+      sessionId: req.sessionId,
+      transcriptVersion,
+      subscribers: new Set<string>([req.terminalId]),
+      attempts: 0,
+      stale: false,
+      promise: this.executeWithRetry(req, session),
+    };
+    this.inFlight.set(cacheKey, job);
+
+    try {
+      const outcome = await job.promise;
+      // If this job was superseded by a newer one for the same session
+      // (transcriptVersion advanced), silently drop the result — the
+      // newer job will deliver a fresher answer.
+      if (job.stale) {
+        diagLog('paneSummary.stale', { sessionId: sanitize(req.sessionId), transcriptVersion });
+        return;
+      }
+      if ('text' in outcome) {
+        this.cache.set(cacheKey, {
+          text: outcome.text,
+          generatedAt: Date.now(),
+          transcriptVersion,
+        });
+        this.purgeStaleCacheEntries();
+        // Fan out result to every subscribed pane.
+        for (const terminalId of job.subscribers) {
+          this.emitResult(sender, {
+            terminalId,
+            sessionId: req.sessionId,
+            provider: req.provider,
+            transcriptVersion,
+            text: outcome.text,
+            generatedAt: this.cache.get(cacheKey)!.generatedAt,
+          });
+        }
+      } else {
+        for (const terminalId of job.subscribers) {
+          this.emitError(sender, {
+            terminalId,
+            sessionId: req.sessionId,
+            provider: req.provider,
+            message: outcome.error,
+            unavailable: outcome.unavailable,
+          });
+        }
+      }
+    } finally {
+      // Only clear the inFlight slot if we're still the current owner;
+      // a newer job may have replaced us already.
+      if (this.inFlight.get(cacheKey) === job) {
+        this.inFlight.delete(cacheKey);
+      }
+      this.activeCount--;
+      this.drainQueue();
+    }
+  }
+
+  private drainQueue(): void {
+    while (this.activeCount < MAX_CONCURRENCY && this.queue.length > 0) {
+      const next = this.queue.shift()!;
+      // The per-item sender may have gone away between enqueue and now.
+      if (next.sender.isDestroyed()) continue;
+      void this.handleRequest(next.req, next.sender);
+    }
+  }
+
+  private async executeWithRetry(
+    req: PaneSummaryRequest,
+    session: CopilotSession,
+  ): Promise<{ text: string } | { error: string; unavailable?: boolean }> {
+    let lastError = 'unknown error';
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const result = await this.executeOnce(req, session);
+        if ('text' in result) return result;
+        if (result.unavailable) return result; // don't retry on unavailable
+        lastError = result.error;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+      diagLog('paneSummary.retry', {
+        sessionId: sanitize(req.sessionId),
+        attempt,
+        lastError,
+      });
+    }
+    return { error: lastError };
+  }
+
+  /** Single attempt: collect transcript → spawn copilot → validate → cleanup. */
+  private async executeOnce(
+    req: PaneSummaryRequest,
+    session: CopilotSession,
+  ): Promise<{ text: string } | { error: string; unavailable?: boolean }> {
+    const transcript = this.buildTranscript(req, session);
+    if (!transcript) {
+      return { error: 'no user prompts found in session', unavailable: false };
+    }
+
+    const summarizerName = `${SUMMARIZER_SESSION_NAME_PREFIX}${randomUUID()}`;
+
+    const t0 = Date.now();
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let spawnError: string | null = null;
+
+    try {
+      ({ stdout, stderr, timedOut } = await this.spawnCopilot(transcript, summarizerName, req.wslDistro));
+    } catch (err) {
+      spawnError = err instanceof Error ? err.message : String(err);
+    }
+
+    const elapsed = Date.now() - t0;
+    diagLog('paneSummary.spawn', {
+      sessionId: sanitize(req.sessionId),
+      provider: req.provider,
+      summarizerName: sanitize(summarizerName),
+      elapsedMs: elapsed,
+      timedOut,
+      hadStderr: stderr.length > 0,
+      hadError: !!spawnError,
+    });
+
+    // Best-effort cleanup: only the session dir we just created. Don't
+    // touch dirs belonging to concurrent summarizer runs.
+    this.cleanupOurSummarizerSession(summarizerName);
+
+    // Detect "command not found" — child.on('error') resolves with the
+    // message folded into stderr, so we must inspect both stderr and
+    // any thrown spawnError.
+    const combined = `${spawnError ?? ''}\n${stderr}`.toLowerCase();
+    if (combined.includes('enoent') || combined.includes('not found') || combined.includes('command not found')) {
+      return { error: 'copilot CLI not found', unavailable: true };
+    }
+    if (spawnError) {
+      return { error: `spawn failed: ${spawnError.slice(0, 120)}` };
+    }
+    if (timedOut) {
+      return { error: `timed out after ${Math.round(SPAWN_TIMEOUT_MS / 1000)}s` };
+    }
+
+    const cleaned = validateAndCleanSummary(stdout);
+    if (!cleaned) {
+      return { error: 'output rejected by validator' };
+    }
+    return { text: cleaned };
+  }
+
+  private buildTranscript(req: PaneSummaryRequest, session: CopilotSession): string | null {
+    // Reuse the cached prompts from copilot-events-parser when possible.
+    const basePath = this.deps.monitor.getBasePath?.() ?? path.join(os.homedir(), '.copilot', 'session-state');
+    const eventsPath = path.join(basePath, req.sessionId, 'events.jsonl');
+    const prompts = extractCopilotPrompts(eventsPath, MAX_PROMPTS_IN_TRANSCRIPT);
+    if (prompts.length === 0) {
+      // Fallback to the single latest prompt on the summary, if any.
+      if (session.latestPrompt) {
+        return this.assemblePrompt([session.latestPrompt]);
+      }
+      return null;
+    }
+    return this.assemblePrompt(prompts);
+  }
+
+  private assemblePrompt(userPrompts: string[]): string {
+    const lines: string[] = [SYSTEM_PROMPT, '', 'Recent user prompts from the session:'];
+    for (const p of userPrompts) {
+      const safe = p.replace(/\u0000/g, '').replace(/\r/g, '').slice(0, MAX_PROMPT_CHARS);
+      // Indent with "> " so the model sees these clearly as quoted user
+      // material rather than its own instructions.
+      for (const line of safe.split('\n')) {
+        lines.push(`> ${line}`);
+      }
+      lines.push('');
+    }
+    lines.push('Now reply with the single-sentence summary, no preamble.');
+    return lines.join('\n');
+  }
+
+  // ── Spawn ────────────────────────────────────────────────────────
+
+  /** Resolve the absolute path to the `copilot` executable.
+   *
+   *  Electron launched from Finder/Dock on macOS gets a stripped PATH
+   *  (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include common
+   *  installation locations like Homebrew's `/opt/homebrew/bin` or
+   *  `~/.local/bin`. `spawn('copilot', …)` then fails with ENOENT and
+   *  the summary never appears. To make the feature work in that
+   *  environment we try a fixed list of common locations and fall back
+   *  to the bare name (so a PATH-augmented shell still works). The
+   *  resolved path is cached for the lifetime of the service. */
+  private resolvedExecutable: string | null = null;
+  private resolveCopilotPath(): string {
+    if (this.deps.resolveExecutable) return this.deps.resolveExecutable();
+    if (this.resolvedExecutable) return this.resolvedExecutable;
+
+    const candidates: string[] = [];
+    if (process.platform === 'win32') {
+      candidates.push('copilot.exe', 'copilot.cmd', 'copilot');
+    } else {
+      const home = os.homedir();
+      candidates.push(
+        '/opt/homebrew/bin/copilot',           // Apple Silicon Homebrew
+        '/usr/local/bin/copilot',              // Intel Homebrew + many installers
+        path.join(home, '.local', 'bin', 'copilot'),
+        path.join(home, '.npm-global', 'bin', 'copilot'),
+        path.join(home, '.nvm', 'versions', 'node', '*', 'bin', 'copilot'),
+      );
+    }
+
+    for (const c of candidates) {
+      // Skip globs — fs.existsSync doesn't expand them.
+      if (c.includes('*')) continue;
+      try {
+        if (fs.existsSync(c)) {
+          this.resolvedExecutable = c;
+          diagLog('paneSummary.exeResolved', { path: c });
+          return c;
+        }
+      } catch { /* ignore */ }
+    }
+
+    // Last resort: search PATH (works when launched from a shell that
+    // augmented PATH already).
+    const pathEnv = process.env.PATH ?? '';
+    const sep = process.platform === 'win32' ? ';' : ':';
+    const exeName = process.platform === 'win32' ? 'copilot.exe' : 'copilot';
+    for (const dir of pathEnv.split(sep)) {
+      if (!dir) continue;
+      const full = path.join(dir, exeName);
+      try {
+        if (fs.existsSync(full)) {
+          this.resolvedExecutable = full;
+          diagLog('paneSummary.exeResolved', { path: full });
+          return full;
+        }
+      } catch { /* ignore */ }
+    }
+
+    // Couldn't resolve — return bare name; spawn will hit ENOENT and we
+    // surface unavailable.
+    diagLog('paneSummary.exeNotResolved', {});
+    return 'copilot';
+  }
+
+  private augmentedPath(): string {
+    const cur = process.env.PATH ?? '';
+    if (process.platform === 'win32') return cur;
+    const sep = ':';
+    const extra = [
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      `${os.homedir()}/.local/bin`,
+      `${os.homedir()}/.npm-global/bin`,
+    ];
+    const existing = new Set(cur.split(sep));
+    const additions = extra.filter((p) => !existing.has(p));
+    return additions.length ? `${cur}${sep}${additions.join(sep)}` : cur;
+  }
+
+  private spawnCopilot(
+    promptText: string,
+    summarizerName: string,
+    wslDistro?: string,
+  ): Promise<{ stdout: string; stderr: string; timedOut: boolean }> {
+    const exe = this.resolveCopilotPath();
+
+    const baseArgs = [
+      '-p', '',
+      '-n', summarizerName,
+      '--silent',
+      '--log-level', 'none',
+      '--effort', 'medium',
+      '--no-ask-user',
+      '--no-custom-instructions',
+      '--no-auto-update',
+      '--no-remote',
+      '--disallow-temp-dir',
+      '--deny-tool', 'shell(*)',
+      '--deny-tool', 'write',
+      '--excluded-tools', 'view,bash,powershell,grep,glob,edit,create',
+      '--allow-all-tools',
+    ];
+
+    let cmd: string;
+    let args: string[];
+    if (wslDistro && process.platform === 'win32') {
+      cmd = 'wsl.exe';
+      args = ['-d', wslDistro, '--', exe, ...baseArgs];
+    } else {
+      cmd = exe;
+      args = baseArgs;
+    }
+
+    return new Promise((resolve) => {
+      let stdout = '';
+      let stderr = '';
+      let timedOut = false;
+      let settled = false;
+
+      const child = spawn(cmd, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+        // Run from a neutral cwd so no cwd-scoped settings or .git affect the spawn.
+        cwd: os.tmpdir(),
+        env: {
+          ...process.env,
+          // Augment PATH so the child can find node/python etc. even when
+          // Electron was launched with a stripped PATH (Finder/Dock).
+          PATH: this.augmentedPath(),
+          // Defence in depth: tell Copilot not to read user instructions
+          // via env vars some shells honour.
+          COPILOT_NONINTERACTIVE: '1',
+        },
+      });
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        try { child.kill('SIGTERM'); } catch { /* ignore */ }
+        // Hard kill 2s later if still alive.
+        setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* ignore */ } }, 2_000);
+      }, SPAWN_TIMEOUT_MS);
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        if (stdout.length < MAX_OUTPUT_CHARS) stdout += chunk.toString('utf8');
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        if (stderr.length < MAX_OUTPUT_CHARS) stderr += chunk.toString('utf8');
+      });
+
+      child.on('error', (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        // Surface ENOENT etc. via stderr-style channel.
+        stderr = (stderr + '\n' + (err?.message ?? String(err))).trim();
+        resolve({ stdout, stderr, timedOut });
+      });
+
+      child.on('close', () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve({ stdout, stderr, timedOut });
+      });
+
+      // Write the prompt to stdin and close. Wrap in try in case the
+      // child died before stdin was ready.
+      try {
+        child.stdin.write(promptText);
+        child.stdin.end();
+      } catch (err) {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve({
+            stdout,
+            stderr: (stderr + '\n' + String(err)).trim(),
+            timedOut,
+          });
+        }
+      }
+    });
+  }
+
+  // ── Session-dir cleanup ──────────────────────────────────────────
+
+  /** Find and remove only the session dir created for this exact spawn,
+   *  identified by `name: tmax-summarizer:<uuid>` in workspace.yaml.
+   *  Safe against concurrent summarizer jobs. */
+  private cleanupOurSummarizerSession(summarizerName: string): void {
+    const baseDir = path.join(os.homedir(), '.copilot', 'session-state');
+    try {
+      if (!fs.existsSync(baseDir)) return;
+      for (const entry of fs.readdirSync(baseDir)) {
+        const full = path.join(baseDir, entry);
+        const wsPath = path.join(full, 'workspace.yaml');
+        if (!fs.existsSync(wsPath)) continue;
+        try {
+          const content = fs.readFileSync(wsPath, 'utf-8');
+          if (new RegExp(`^(name|summary):\\s*${escapeRegExp(summarizerName)}\\s*$`, 'm').test(content)) {
+            try { fs.rmSync(full, { recursive: true, force: true }); } catch { /* ignore */ }
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    } catch { /* ignore */ }
+  }
+
+  /** Best-effort sweep of ALL leftover summarizer dirs. Only called from
+   *  dispose() — when the service is shutting down nothing else is
+   *  spawning, so the cross-run race in #7 doesn't apply. */
+  private sweepAllSummarizerSessions(): void {
+    const baseDir = path.join(os.homedir(), '.copilot', 'session-state');
+    try {
+      if (!fs.existsSync(baseDir)) return;
+      for (const entry of fs.readdirSync(baseDir)) {
+        const full = path.join(baseDir, entry);
+        if (this.isOurSummarizerDir(full)) {
+          try { fs.rmSync(full, { recursive: true, force: true }); } catch { /* ignore */ }
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  private isOurSummarizerDir(fullPath: string): boolean {
+    try {
+      const wsPath = path.join(fullPath, 'workspace.yaml');
+      if (!fs.existsSync(wsPath)) return false;
+      const content = fs.readFileSync(wsPath, 'utf-8');
+      // Match either `name: tmax-summarizer:…` or `summary: tmax-summarizer:…`
+      // because CLI versions differ on which field holds `-n`.
+      return new RegExp(`^(name|summary):\\s*${SUMMARIZER_SESSION_NAME_PREFIX}`, 'm').test(content);
+    } catch {
+      return false;
+    }
+  }
+
+  // ── Cache ────────────────────────────────────────────────────────
+
+  private purgeStaleCacheEntries(): void {
+    if (this.cache.size <= 64) return;
+    const now = Date.now();
+    for (const [k, v] of this.cache) {
+      if (now - v.generatedAt > CACHE_TTL_MS) this.cache.delete(k);
+    }
+    // Hard cap: if still > 64, evict oldest.
+    if (this.cache.size > 64) {
+      const sorted = Array.from(this.cache.entries()).sort((a, b) => a[1].generatedAt - b[1].generatedAt);
+      const toDrop = sorted.slice(0, this.cache.size - 64);
+      for (const [k] of toDrop) this.cache.delete(k);
+    }
+  }
+
+  // ── IPC emit (per-sender to avoid leaking summaries to other windows) ──
+
+  private emitResult(sender: Electron.WebContents, result: PaneSummaryResult): void {
+    this.send(sender, IPC.PANE_SUMMARY_RESULT, result);
+  }
+
+  private emitError(sender: Electron.WebContents, err: PaneSummaryError): void {
+    this.send(sender, IPC.PANE_SUMMARY_ERROR, err);
+  }
+
+  private send(sender: Electron.WebContents, channel: string, payload: unknown): void {
+    try {
+      if (!sender.isDestroyed()) sender.send(channel, payload);
+    } catch { /* ignore */ }
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────
+
+  /** Clear cache and pending state. Safe to call repeatedly. */
+  dispose(): void {
+    this.disposed = true;
+    this.cache.clear();
+    this.inFlight.clear();
+    this.queue.length = 0;
+    // Shutdown-time sweep — no concurrent summarizers to race with.
+    this.sweepAllSummarizerSessions();
+  }
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -2,6 +2,11 @@ import { contextBridge, ipcRenderer, clipboard } from 'electron';
 import { IPC } from '../shared/ipc-channels';
 import type { DiffMode, DiffResult, AnnotatedFile } from '../shared/diff-types';
 import type { RepoWorktrees } from '../shared/worktree-types';
+import type {
+  PaneSummaryRequest,
+  PaneSummaryResult,
+  PaneSummaryError,
+} from '../shared/pane-summary-types';
 
 export interface PtyDiag {
   pid: number;
@@ -78,6 +83,13 @@ export interface TerminalAPI {
   onSessionFileChanged(cb: () => void): () => void;
   // ── Child process tree query (TASK-171) ────────────────────────────
   getPtyChildProcesses(ptyId: string): Promise<string[]>;
+  // ── Pane summary (AI-distilled 1-liner) ────────────────────────────
+  /** Request a fresh summary. Fire-and-forget; the response arrives via
+   *  `onPaneSummaryResult` or `onPaneSummaryError`. Safe to call repeatedly:
+   *  the main service deduplicates by sessionId+transcriptVersion. */
+  requestPaneSummary(req: PaneSummaryRequest): void;
+  onPaneSummaryResult(cb: (result: PaneSummaryResult) => void): () => void;
+  onPaneSummaryError(cb: (err: PaneSummaryError) => void): () => void;
 }
 
 const terminalAPI: TerminalAPI = {
@@ -451,6 +463,23 @@ const terminalAPI: TerminalAPI = {
   // ── Child process tree query (TASK-171) ────────────────────────────
   getPtyChildProcesses(ptyId: string) {
     return ipcRenderer.invoke(IPC.PTY_GET_CHILD_PROCESSES, ptyId);
+  },
+
+  // ── Pane summary (AI-distilled 1-liner) ────────────────────────────
+  requestPaneSummary(req: PaneSummaryRequest) {
+    ipcRenderer.send(IPC.PANE_SUMMARY_REQUEST, req);
+  },
+
+  onPaneSummaryResult(cb: (result: PaneSummaryResult) => void): () => void {
+    const listener = (_e: Electron.IpcRendererEvent, result: PaneSummaryResult) => cb(result);
+    ipcRenderer.on(IPC.PANE_SUMMARY_RESULT, listener);
+    return () => ipcRenderer.removeListener(IPC.PANE_SUMMARY_RESULT, listener);
+  },
+
+  onPaneSummaryError(cb: (err: PaneSummaryError) => void): () => void {
+    const listener = (_e: Electron.IpcRendererEvent, err: PaneSummaryError) => cb(err);
+    ipcRenderer.on(IPC.PANE_SUMMARY_ERROR, listener);
+    return () => ipcRenderer.removeListener(IPC.PANE_SUMMARY_ERROR, listener);
   },
 
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,8 +8,10 @@ import { useTerminalStore } from './state/terminal-store';
 import { getTerminalEntry } from './terminal-registry';
 import { applyChromeFromTheme } from './utils/theme-presets';
 import type { CopilotSessionSummary } from '../shared/copilot-types';
+import type { PaneSummaryResult, PaneSummaryError } from '../shared/pane-summary-types';
 import { useKeybindings } from './hooks/useKeybindings';
 import { useDragTerminal } from './hooks/useDragTerminal';
+import { useAutoPaneSummary } from './hooks/useAutoPaneSummary';
 import TabBar from './components/TabBar';
 import WorkspaceTabBar from './components/WorkspaceTabBar';
 import TilingLayout from './components/TilingLayout';
@@ -88,6 +90,7 @@ const App: React.FC = () => {
   }, []);
 
   useKeybindings();
+  useAutoPaneSummary();
 
   const {
     activeId,
@@ -267,6 +270,14 @@ const App: React.FC = () => {
       store().addToast('Keybindings reloaded');
     });
 
+    // ── Pane summary IPC subscriptions (Task pane-summary) ──────────
+    const unsubPaneSummaryResult = api.onPaneSummaryResult?.((result: PaneSummaryResult) => {
+      store().applyPaneSummaryResult(result);
+    });
+    const unsubPaneSummaryError = api.onPaneSummaryError?.((err: PaneSummaryError) => {
+      store().applyPaneSummaryError(err);
+    });
+
     return () => {
       api.stopCopilotWatching?.();
       api.stopClaudeCodeWatching?.();
@@ -277,6 +288,8 @@ const App: React.FC = () => {
       unsubClaudeAdded?.();
       unsubClaudeRemoved?.();
       unsubKeybindings?.();
+      unsubPaneSummaryResult?.();
+      unsubPaneSummaryError?.();
     };
   }, []);
 

--- a/src/renderer/components/CopilotPanel.tsx
+++ b/src/renderer/components/CopilotPanel.tsx
@@ -4,6 +4,7 @@ import { useTerminalStore } from '../state/terminal-store';
 import { getTerminalEntry } from '../terminal-registry';
 import { runJumpToPromptSearch } from '../utils/jump-to-prompt';
 import { renderWithMdLinks } from '../utils/md-link-parser';
+import SessionTitleTooltip from './SessionTitleTooltip';
 import { tokenizeAnd, matchesAllTokens } from '../../shared/and-filter';
 import type { CopilotSessionSummary, CopilotSessionStatus, SessionProvider, SessionLifecycle } from '../../shared/copilot-types';
 import { detectSessionHost, stripClawpilotContext } from '../../shared/copilot-types';
@@ -194,6 +195,17 @@ const CopilotPanel: React.FC = () => {
   const claudeCodeSessions = useTerminalStore((s) => s.claudeCodeSessions);
   const terminals = useTerminalStore((s) => s.terminals);
   const summaryOverrides = useTerminalStore((s) => s.sessionNameOverrides);
+  const paneSummaries = useTerminalStore((s) => s.paneSummaries);
+  // Build a {sessionId → AI summary text} map keyed on session id. Lets
+  // the list rows derive the display title cheaply without scanning the
+  // whole paneSummaries map per row.
+  const aiSummaryBySessionId = useMemo(() => {
+    const out = new Map<string, string>();
+    for (const ps of Object.values(paneSummaries)) {
+      if (ps.status === 'ready' && ps.text) out.set(ps.sessionId, ps.text);
+    }
+    return out;
+  }, [paneSummaries]);
   const lifecycleOverrides = useTerminalStore((s) => s.sessionLifecycleOverrides);
   const pinnedSessions = useTerminalStore((s) => s.sessionPinned);
   const focusedTerminalId = useTerminalStore((s) => s.focusedTerminalId);
@@ -525,18 +537,28 @@ const CopilotPanel: React.FC = () => {
 
   // Sessions that share the exact same title - automation scripts often spawn
   // many `claude` runs with the same initial prompt, making them visually
-  // indistinguishable. Flag duplicates so the render can append a short
-  // session-ID suffix to disambiguate.
+  // indistinguishable.
+  //
+  // Disambiguation suffix - when multiple sessions resolve to the same
+  // visible title (e.g. several sessions in the same repo, all using
+  // their cwd as fallback because no override or AI summary yet), the
+  // titles become indistinguishable. Flag duplicates so the render can
+  // append a short session-ID suffix to disambiguate.
+  //
+  // IMPORTANT: this MUST use the same precedence as the rendered title
+  // (manual override > AI summary > getTitle fallback), otherwise we'd
+  // either fail to flag real visual duplicates or flag false ones.
   const dupTitles = useMemo(() => {
     const counts = new Map<string, number>();
     for (const s of displayList) {
-      const t = getTitle(s);
+      const ai = aiSummaryBySessionId.get(s.id);
+      const t = summaryOverrides[s.id] ? getTitle(s) : (ai || getTitle(s));
       counts.set(t, (counts.get(t) || 0) + 1);
     }
     const dups = new Set<string>();
     for (const [t, n] of counts) if (n > 1) dups.add(t);
     return dups;
-  }, [displayList]);
+  }, [displayList, aiSummaryBySessionId, summaryOverrides]);
 
   // Lifecycle counts (for tab badges) — computed from all sessions regardless of provider/running filter
   const lifecycleCounts = useMemo(() => {
@@ -708,7 +730,14 @@ const CopilotPanel: React.FC = () => {
   }, []);
 
   const handleStartRename = useCallback((session: CopilotSessionSummary) => {
-    setRenaming({ id: session.id, provider: session.provider, value: summaryOverrides[session.id] || session.summary || getTitle(session) });
+    setRenaming({
+      id: session.id,
+      provider: session.provider,
+      value: summaryOverrides[session.id]
+        || aiSummaryBySessionId.get(session.id)
+        || session.summary
+        || getTitle(session),
+    });
     setCtxMenu(null);
   }, []);
 
@@ -1230,7 +1259,22 @@ const CopilotPanel: React.FC = () => {
 
       <div className="dir-panel-list" ref={listRef}>
         {displayList.slice(0, renderLimit).map((session, index) => {
-          const title = getTitle(session);
+          // Title precedence:
+          //   1. Manual rename (sessionNameOverride) - user is always in
+          //      control if they explicitly set a name.
+          //   2. AI one-line summary (Task pane-summary), when ready.
+          //   3. Original derivation from session.summary / cwd / id.
+          //
+          // Note that the displayList already has the override merged
+          // into session.summary (mapping at the filter step), so we
+          // look at the raw override map here to detect "user has set a
+          // title" without confusing it with Copilot's own auto-summary.
+          const hasManualOverride = !!summaryOverrides[session.id];
+          const aiSummaryText = aiSummaryBySessionId.get(session.id);
+          const fallbackTitle = getTitle(session);
+          const title = hasManualOverride
+            ? fallbackTitle
+            : (aiSummaryText || fallbackTitle);
           const subtitle = getSubtitle(session);
           const active = isActiveStatus(session.status);
           const isOpen = openSessionIds.has(session.id);
@@ -1329,12 +1373,18 @@ const CopilotPanel: React.FC = () => {
                       onClick={(e) => e.stopPropagation()}
                     />
                   ) : (
-                    <span className="ai-session-name" title={title}>
-                      {renderWithMdLinks(title, session.cwd)}
-                      {dupTitles.has(title) && (
-                        <span className="ai-session-iddup" title={session.id}> · {session.id.slice(0, 6)}</span>
-                      )}
-                    </span>
+                    <SessionTitleTooltip
+                      sessionId={session.id}
+                      provider={session.provider as 'copilot' | 'claude-code'}
+                      messageCount={session.messageCount || 0}
+                    >
+                      <span className="ai-session-name">
+                        {renderWithMdLinks(title, session.cwd)}
+                        {dupTitles.has(title) && (
+                          <span className="ai-session-iddup" title={session.id}> · {session.id.slice(0, 6)}</span>
+                        )}
+                      </span>
+                    </SessionTitleTooltip>
                   )}
                   {isOpen && <span className="ai-open-badge">OPEN</span>}
                   {session.wsl && (

--- a/src/renderer/components/HoverTooltip.tsx
+++ b/src/renderer/components/HoverTooltip.tsx
@@ -1,0 +1,117 @@
+// HoverTooltip — shared infrastructure for pane-summary tooltips
+//
+// Handles the parts that are identical across every summary tooltip:
+//   - 500ms hover-intent delay
+//   - portal render anchored under the wrapped element
+//   - viewport-clamped centred positioning
+//   - timer cleanup on unmount / leave
+//   - display:contents wrapper that walks into firstElementChild so
+//     flex layouts (tabs!) keep their original sizing and the
+//     getBoundingClientRect() call returns a real rect.
+//
+// Each caller (PaneSummaryTooltip, SessionTitleTooltip) supplies:
+//   - renderBody(): the state-specific tooltip content (return null to suppress)
+//   - onShow():     fired once the tooltip becomes visible (e.g. to kick off a
+//                   summary request)
+
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+
+const HOVER_DELAY_MS = 500;
+const TOOLTIP_OFFSET_Y = 8;
+const TOOLTIP_MAX_WIDTH = 360;
+
+export interface HoverTooltipProps {
+  children: React.ReactElement;
+  disabled?: boolean;
+  /** Render the tooltip body. Return null to hide the tooltip entirely. */
+  renderBody: () => React.ReactNode | null;
+  /** Called once when the tooltip becomes visible (after the hover delay). */
+  onShow?: () => void;
+}
+
+interface TooltipState {
+  visible: boolean;
+  x: number;
+  y: number;
+}
+
+function positionFor(target: HTMLElement): { x: number; y: number } {
+  // Wrapper uses display:contents and has no box of its own. Walk into
+  // the first child for a real rect; fall back to the wrapper if needed.
+  const childEl = (target.firstElementChild as HTMLElement | null) ?? target;
+  let rect = childEl.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) {
+    rect = target.getBoundingClientRect();
+  }
+  const x = Math.max(
+    8,
+    Math.min(
+      window.innerWidth - TOOLTIP_MAX_WIDTH - 8,
+      rect.left + rect.width / 2 - TOOLTIP_MAX_WIDTH / 2,
+    ),
+  );
+  const y = rect.bottom + TOOLTIP_OFFSET_Y;
+  return { x, y };
+}
+
+const HoverTooltip: React.FC<HoverTooltipProps> = ({ children, disabled, renderBody, onShow }) => {
+  const [tooltip, setTooltip] = useState<TooltipState>({ visible: false, x: 0, y: 0 });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback((e: React.MouseEvent) => {
+    if (disabled) return;
+    const target = e.currentTarget as HTMLElement;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      const { x, y } = positionFor(target);
+      setTooltip({ visible: true, x, y });
+      onShow?.();
+    }, HOVER_DELAY_MS);
+  }, [disabled, onShow]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setTooltip({ visible: false, x: 0, y: 0 });
+  }, []);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  const body = tooltip.visible ? renderBody() : null;
+
+  return (
+    <>
+      <span
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        style={{ display: 'contents' }}
+      >
+        {children}
+      </span>
+      {tooltip.visible && body !== null && ReactDOM.createPortal(
+        <div
+          className="pane-summary-tooltip"
+          role="tooltip"
+          style={{
+            position: 'fixed',
+            left: tooltip.x,
+            top: tooltip.y,
+            maxWidth: TOOLTIP_MAX_WIDTH,
+            zIndex: 99999,
+            pointerEvents: 'none',
+          }}
+        >
+          {body}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+};
+
+export default HoverTooltip;

--- a/src/renderer/components/PaneSummaryTooltip.tsx
+++ b/src/renderer/components/PaneSummaryTooltip.tsx
@@ -1,0 +1,62 @@
+// PaneSummaryTooltip — terminal-keyed pane-summary tooltip.
+//
+// Thin wrapper over HoverTooltip that reads pane-summary state for a
+// specific terminalId and produces state-aware body text. Used on tabs
+// and pane headers, where each pane maps 1:1 to a terminalId.
+
+import React from 'react';
+import HoverTooltip from './HoverTooltip';
+import { useTerminalStore } from '../state/terminal-store';
+import type { TerminalId } from '../state/types';
+import type { PaneSummary } from '../../shared/pane-summary-types';
+import { MutedBody, renderSummaryStatus } from './summary-tooltip-body';
+
+interface PaneSummaryTooltipProps {
+  terminalId: TerminalId;
+  children: React.ReactElement;
+  /** Disable hover behaviour (e.g. while renaming). */
+  disabled?: boolean;
+}
+
+const PaneSummaryTooltip: React.FC<PaneSummaryTooltipProps> = ({ terminalId, children, disabled }) => {
+  const summary = useTerminalStore((s) => s.paneSummaries[terminalId]);
+  const aiSessionId = useTerminalStore((s) => s.terminals.get(terminalId)?.aiSessionId);
+  const requestPaneSummary = useTerminalStore((s) => s.requestPaneSummary);
+
+  const onShow = () => {
+    // If we have an AI session but no summary yet, kick off a request.
+    // The auto-trigger hook normally handles this — but if the user
+    // hovers earlier than the 5-min delay, honor their intent.
+    if (aiSessionId && (!summary || summary.status === 'idle')) {
+      requestPaneSummary(terminalId);
+    }
+  };
+
+  const renderBody = () => renderPaneBody(aiSessionId, summary);
+
+  return (
+    <HoverTooltip disabled={disabled} renderBody={renderBody} onShow={onShow}>
+      {children}
+    </HoverTooltip>
+  );
+};
+
+function renderPaneBody(
+  aiSessionId: string | undefined,
+  summary: PaneSummary | undefined,
+): React.ReactNode | null {
+  // No AI session linked → suppress the tooltip entirely so plain
+  // terminals don't get a useless hover.
+  if (!aiSessionId) return null;
+
+  // Pane tooltips surface stale text during refresh so the user is
+  // never left staring at a "Generating…" message when there's an old
+  // result available.
+  const statusBody = renderSummaryStatus(summary, { showStaleText: true });
+  if (statusBody !== undefined) return statusBody;
+
+  // Idle / no summary yet.
+  return <MutedBody>Summary will appear once the session has a few prompts.</MutedBody>;
+}
+
+export default PaneSummaryTooltip;

--- a/src/renderer/components/SessionTitleTooltip.tsx
+++ b/src/renderer/components/SessionTitleTooltip.tsx
@@ -1,0 +1,89 @@
+// SessionTitleTooltip — session-keyed pane-summary tooltip.
+//
+// Used in the CopilotPanel sidebar, where the anchor is a session
+// (not a terminal). When at least one terminal is linked to the
+// session we drive the summary request via that terminalId (cache is
+// session-keyed internally so any linked terminal works). When no
+// terminal is linked we still show any cached result and otherwise
+// nudge the user to open the session in a tab.
+
+import React from 'react';
+import HoverTooltip from './HoverTooltip';
+import { useTerminalStore } from '../state/terminal-store';
+import type { PaneSummary } from '../../shared/pane-summary-types';
+import { MutedBody, renderSummaryStatus } from './summary-tooltip-body';
+
+interface Props {
+  sessionId: string;
+  provider: 'copilot' | 'claude-code';
+  /** Session message count — gates the "needs a few prompts" hint. */
+  messageCount: number;
+  children: React.ReactElement;
+  disabled?: boolean;
+}
+
+const SessionTitleTooltip: React.FC<Props> = ({ sessionId, provider, messageCount, children, disabled }) => {
+  const linkedTerminalId = useTerminalStore((s) => {
+    for (const [tid, t] of s.terminals) {
+      if (t.aiSessionId === sessionId) return tid;
+    }
+    return null;
+  });
+
+  const summary: PaneSummary | undefined = useTerminalStore((s) => {
+    if (linkedTerminalId) {
+      const fromLinked = s.paneSummaries[linkedTerminalId];
+      if (fromLinked) return fromLinked;
+    }
+    // Defensive scan: a terminal may have closed but the result is still
+    // cached against its old id.
+    for (const ps of Object.values(s.paneSummaries)) {
+      if (ps.sessionId === sessionId && ps.status === 'ready') return ps;
+    }
+    return undefined;
+  });
+
+  const requestPaneSummary = useTerminalStore((s) => s.requestPaneSummary);
+
+  const onShow = () => {
+    if (linkedTerminalId && (!summary || summary.status === 'idle')) {
+      requestPaneSummary(linkedTerminalId);
+    }
+  };
+
+  const renderBody = () => renderSessionBody(provider, messageCount, linkedTerminalId !== null, summary);
+
+  return (
+    <HoverTooltip disabled={disabled} renderBody={renderBody} onShow={onShow}>
+      {children}
+    </HoverTooltip>
+  );
+};
+
+function renderSessionBody(
+  provider: 'copilot' | 'claude-code',
+  messageCount: number,
+  hasLinkedTerminal: boolean,
+  summary: PaneSummary | undefined,
+): React.ReactNode | null {
+  // v1 — only Copilot is wired into the summarizer.
+  if (provider !== 'copilot') {
+    return <MutedBody>AI summary is available for Copilot sessions only (v1).</MutedBody>;
+  }
+
+  // Sidebar tooltips do not surface stale text — when a refresh is in
+  // flight we want a clean "Generating…" message rather than text that
+  // may no longer reflect the session.
+  const statusBody = renderSummaryStatus(summary, { showStaleText: false });
+  if (statusBody !== undefined) return statusBody;
+
+  if (!hasLinkedTerminal) {
+    return <MutedBody>Open this session in a tab to generate an AI summary.</MutedBody>;
+  }
+  if (messageCount < 3) {
+    return <MutedBody>Summary will appear once the session has a few prompts.</MutedBody>;
+  }
+  return <MutedBody>Generating summary…</MutedBody>;
+}
+
+export default SessionTitleTooltip;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -263,6 +263,38 @@ const TerminalSettings: React.FC = () => {
               update({ aiSessionLoadLimit: clamped } as any);
             }} />
         </SettingRow>
+        {/* Pane summary (Task pane-summary) — hover tooltip + ⋯ menu show
+            a 1-sentence AI-distilled summary of each pane's session.
+            v1 supports Copilot only. */}
+        <SettingRow label="Pane summary" description="Hover a tab/pane title or open the ⋯ menu to see a 1-line AI summary of the session. v1: Copilot only; uses a sandboxed `copilot -p` invocation.">
+          <label className="toggle-switch">
+            <input type="checkbox"
+              checked={(config as any).paneSummary?.enabled !== false}
+              onChange={(e) => update({
+                paneSummary: {
+                  ...((config as any).paneSummary ?? {}),
+                  enabled: e.target.checked,
+                  delayMs: (config as any).paneSummary?.delayMs ?? 5 * 60 * 1000,
+                },
+              } as any)} />
+            <span className="toggle-track" />
+          </label>
+        </SettingRow>
+        <SettingRow label="Pane summary delay (minutes)" description="How long after a session starts before the first auto-summary fires. Also requires ≥3 user prompts in the session.">
+          <input type="number" className="settings-input small" min={0} step={1}
+            value={Math.round(((config as any).paneSummary?.delayMs ?? 5 * 60 * 1000) / 60_000)}
+            onChange={(e) => {
+              const n = parseInt(e.target.value, 10);
+              const minutes = Number.isFinite(n) && n >= 0 ? n : 5;
+              update({
+                paneSummary: {
+                  enabled: (config as any).paneSummary?.enabled !== false,
+                  ...((config as any).paneSummary ?? {}),
+                  delayMs: minutes * 60_000,
+                },
+              } as any);
+            }} />
+        </SettingRow>
         <SettingRow label="Old session threshold" description="Days of inactivity before a session is marked as Old">
           <input type="number" className="settings-input small" value={(config as any).oldSessionDays ?? 30}
             onChange={(e) => update({ oldSessionDays: parseInt(e.target.value) || 30 } as any)} />

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -5,6 +5,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useTerminalStore, TAB_COLORS } from '../state/terminal-store';
 import type { TerminalId } from '../state/types';
 import TabContextMenu, { type ContextMenuPosition } from './TabContextMenu';
+import PaneSummaryTooltip from './PaneSummaryTooltip';
 import { isMac } from '../utils/platform';
 
 interface TabProps {
@@ -33,15 +34,39 @@ const Tab: React.FC<TabProps> = ({
   const [renameValue, setRenameValue] = useState(title);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const terminal = useTerminalStore((s) => s.terminals.get(terminalId));
+  // AI summary as tab title (Task pane-summary): when the pane has a
+  // linked AI session and we have a ready summary, and the user hasn't
+  // explicitly renamed the session, use the AI summary as the visible
+  // title. CSS already truncates with ellipsis; PaneSummaryTooltip
+  // below shows the full text on hover.
+  //
+  // Source of truth for "user renamed this session" is
+  // sessionNameOverrides[aiSessionId] - this is the only place where
+  // an explicit user rename for an AI session lives. The
+  // customTitle/aiAutoTitle flags on TerminalInstance can be true for
+  // a number of reasons (OSC titles, first-command auto-rename, etc.)
+  // and aren't a reliable signal here.
+  const aiSummaryText = useTerminalStore(
+    (s) => s.paneSummaries[terminalId]?.status === 'ready'
+      ? s.paneSummaries[terminalId].text
+      : null,
+  );
+  const sessionWasRenamedByUser = useTerminalStore((s) => {
+    const sid = terminal?.aiSessionId;
+    return !!sid && !!s.sessionNameOverrides[sid];
+  });
+  const displayTitle = sessionWasRenamedByUser ? title : (aiSummaryText || title);
+
   useEffect(() => {
     if (isRenaming) {
-      setRenameValue(title);
+      setRenameValue(displayTitle);
       requestAnimationFrame(() => {
         inputRef.current?.focus();
         inputRef.current?.select();
       });
     }
-  }, [isRenaming, title]);
+  }, [isRenaming, displayTitle]);
 
   const handleRenameSubmit = useCallback(() => {
     if (renameValue.trim()) {
@@ -56,7 +81,6 @@ const Tab: React.FC<TabProps> = ({
     if (e.key === 'Escape') useTerminalStore.getState().startRenaming(null);
   }, [handleRenameSubmit]);
 
-  const terminal = useTerminalStore((s) => s.terminals.get(terminalId));
   const isDormant = terminal?.mode === 'dormant';
   const isDetached = terminal?.mode === 'detached';
   const tabColor = terminal?.tabColor;
@@ -154,7 +178,9 @@ const Tab: React.FC<TabProps> = ({
       ) : (
         <>
           {isInGrid && viewMode === 'grid' && <span className="tab-split-dot" />}
-          <span className="tab-title">{title}</span>
+          <PaneSummaryTooltip terminalId={terminalId}>
+            <span className="tab-title">{displayTitle}</span>
+          </PaneSummaryTooltip>
         </>
       )}
       {showCloseBtn && (

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -5,6 +5,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { useTerminalStore } from '../state/terminal-store';
+import PaneSummaryTooltip from './PaneSummaryTooltip';
 import { registerTerminal, unregisterTerminal } from '../terminal-registry';
 import { saveTerminalBuffer, popTerminalBuffer } from '../terminal-buffer-cache';
 import { isMac, formatKeyForPlatform } from '../utils/platform';
@@ -2464,6 +2465,24 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
 
   // Apply tab color or default color as terminal background tint via CSS overlay
   const title = useTerminalStore((s) => s.terminals.get(terminalId)?.title);
+  // Task pane-summary: derive an effective title that uses the AI
+  // one-liner when the user hasn't manually renamed the linked AI
+  // session. Source of truth for "user renamed" is
+  // sessionNameOverrides[aiSessionId] - the TerminalInstance flags
+  // (customTitle / aiAutoTitle / firstCommandTitle) are too noisy to
+  // rely on here because OSC and auto-link paths flip them too.
+  const titleAiSessionId = useTerminalStore((s) => s.terminals.get(terminalId)?.aiSessionId);
+  const aiSummaryTitleText = useTerminalStore(
+    (s) => s.paneSummaries[terminalId]?.status === 'ready'
+      ? s.paneSummaries[terminalId].text
+      : null,
+  );
+  const sessionRenamedByUser = useTerminalStore(
+    (s) => !!titleAiSessionId && !!s.sessionNameOverrides[titleAiSessionId],
+  );
+  const displayTitle = sessionRenamedByUser
+    ? (title || '')
+    : (aiSummaryTitleText || title || '');
   const tabColor = useTerminalStore((s) => s.terminals.get(terminalId)?.tabColor);
   const groupId = useTerminalStore((s) => s.terminals.get(terminalId)?.groupId);
   const groupColor = useTerminalStore((s) => groupId ? s.tabGroups.get(groupId)?.color : undefined);
@@ -2759,17 +2778,19 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
               onFocus={(e) => e.target.select()}
             />
           ) : (
-            <span
-              className="terminal-pane-title-text"
-              onDoubleClick={(e) => {
-                // In float mode the parent has its own dblclick handler
-                // (maximize-toggle); we don't want both rename AND maximize
-                // on a single dblclick.
-                e.stopPropagation();
-                setRenameValue(title || '');
-                setIsRenamingPane(true);
-              }}
-            >{title}</span>
+            <PaneSummaryTooltip terminalId={terminalId}>
+              <span
+                className="terminal-pane-title-text"
+                onDoubleClick={(e) => {
+                  // In float mode the parent has its own dblclick handler
+                  // (maximize-toggle); we don't want both rename AND maximize
+                  // on a single dblclick.
+                  e.stopPropagation();
+                  setRenameValue(displayTitle || '');
+                  setIsRenamingPane(true);
+                }}
+              >{displayTitle}</span>
+            </PaneSummaryTooltip>
           )}
           {(() => {
             // TASK-139: Float / Restore button next to the ⋯ menu. Tooltip

--- a/src/renderer/components/summary-tooltip-body.tsx
+++ b/src/renderer/components/summary-tooltip-body.tsx
@@ -1,0 +1,88 @@
+// Shared body primitives for pane-summary tooltips.
+//
+// PaneSummaryTooltip and SessionTitleTooltip both have to render the
+// same set of states (ready / pending / unavailable / error) with the
+// same CSS classes. They differ only in (a) preconditions before any
+// status is consulted (e.g. "no AI session" or "Claude not supported")
+// and (b) whether to surface stale text while a refresh is in flight.
+//
+// `renderSummaryStatus` covers the shared states; the wrappers handle
+// their own preconditions and the "no summary yet" fallback.
+
+import React from 'react';
+import type { PaneSummary } from '../../shared/pane-summary-types';
+
+export const MutedBody: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="pane-summary-tooltip-body pane-summary-tooltip-muted">{children}</div>
+);
+
+export const ReadyBody: React.FC<{ text: string; meta?: React.ReactNode }> = ({ text, meta }) => (
+  <div className="pane-summary-tooltip-body">
+    <div className="pane-summary-tooltip-text">{text}</div>
+    {meta}
+  </div>
+);
+
+export interface SummaryStatusOptions {
+  /** When true, surface stale `summary.text` during pending/error refresh
+   *  states with a small meta line ("Refreshing…" / "Last refresh failed.").
+   *  When false, always show the muted status message regardless of any
+   *  stale text. */
+  showStaleText: boolean;
+}
+
+/**
+ * Render the body for the standard summary states.
+ * Returns `undefined` when no opinion exists (idle, no summary, or
+ * pending/error without text in non-stale mode) — the caller decides
+ * what to show in those gaps.
+ */
+export function renderSummaryStatus(
+  summary: PaneSummary | undefined,
+  opts: SummaryStatusOptions,
+): React.ReactNode | undefined {
+  if (!summary) return undefined;
+
+  if (summary.status === 'ready' && summary.text) {
+    return <ReadyBody text={summary.text} />;
+  }
+
+  if (summary.status === 'unavailable') {
+    return (
+      <MutedBody>
+        Summary not available: {summary.lastError ?? 'provider unavailable'}.
+      </MutedBody>
+    );
+  }
+
+  if (summary.status === 'pending') {
+    if (opts.showStaleText && summary.text) {
+      return (
+        <ReadyBody
+          text={summary.text}
+          meta={<div className="pane-summary-tooltip-meta">Refreshing…</div>}
+        />
+      );
+    }
+    return <MutedBody>Generating summary…</MutedBody>;
+  }
+
+  if (summary.status === 'error') {
+    if (opts.showStaleText && summary.text) {
+      return (
+        <ReadyBody
+          text={summary.text}
+          meta={<div className="pane-summary-tooltip-meta">Last refresh failed.</div>}
+        />
+      );
+    }
+    return (
+      <MutedBody>
+        Couldn't generate summary{summary.lastError ? `: ${summary.lastError}` : ''}.
+      </MutedBody>
+    );
+  }
+
+  // 'idle' or any other status — caller decides.
+  return undefined;
+}

--- a/src/renderer/hooks/useAutoPaneSummary.ts
+++ b/src/renderer/hooks/useAutoPaneSummary.ts
@@ -1,0 +1,163 @@
+// useAutoPaneSummary — Task pane-summary (T3)
+//
+// Per-pane scheduler that fires the auto-summary at the right time:
+//
+//   1. The pane must be linked to a Copilot AI session.
+//   2. At least `delayMs` (default 5 min) must have passed since the
+//      pane was created OR since the session became active.
+//   3. The session must have ≥3 user prompts (otherwise the summary
+//      would be uselessly generic).
+//   4. We re-fire whenever messageCount jumps by ≥5 since the last
+//      successful summary, with a cooldown to avoid churn during a
+//      rapid burst of prompts.
+//
+// We deliberately DO NOT auto-fire on hover. Hover triggers a render of
+// the existing summary or — if none exists — kicks off a request via
+// the same hook's `request()` action when status === 'idle'. That's
+// owned by the tooltip component, not this hook.
+//
+// One useAutoPaneSummary hook instance lives at the App level and
+// watches the entire store. We keep last-fired bookkeeping in a ref
+// so it doesn't trigger re-renders.
+
+import { useEffect, useRef } from 'react';
+import { useTerminalStore } from '../state/terminal-store';
+import { DEFAULT_PANE_SUMMARY_CONFIG } from '../../shared/pane-summary-types';
+import type { TerminalId } from '../state/types';
+
+const MIN_PROMPTS_FOR_FIRST_SUMMARY = 3;
+const MESSAGE_DELTA_FOR_REFRESH = 5;
+/** Don't re-fire more than once per cooldown window per pane, even on a
+ *  big messageCount jump. */
+const REFRESH_COOLDOWN_MS = 90 * 1000;
+/** How often the scheduler tick runs. */
+const TICK_INTERVAL_MS = 30 * 1000;
+
+interface PerPaneBookkeeping {
+  /** ms since epoch when we last fired a request (success OR fail). */
+  lastFiredAt: number;
+  /** messageCount the last successful summary was generated against. */
+  lastSummarisedMessageCount: number;
+}
+
+export function useAutoPaneSummary(): void {
+  const bookkeeping = useRef(new Map<TerminalId, PerPaneBookkeeping>());
+
+  useEffect(() => {
+    const evaluate = () => {
+      const state = useTerminalStore.getState();
+      const config = state.config?.paneSummary ?? DEFAULT_PANE_SUMMARY_CONFIG;
+      if (!config.enabled) return;
+
+      const now = Date.now();
+      const delayMs = config.delayMs ?? DEFAULT_PANE_SUMMARY_CONFIG.delayMs;
+
+      for (const [terminalId, terminal] of state.terminals) {
+        if (!terminal.aiSessionId) continue;
+
+        // Look up the linked AI session (v1 = copilot only).
+        const session = state.copilotSessions.find((s) => s.id === terminal.aiSessionId);
+        if (!session) continue;
+
+        // Need a sense of "session age" — use createdAt if present,
+        // otherwise lastActivityTime minus delayMs (gives us the first
+        // possible auto-fire as soon as we discover an old session).
+        const sessionAge = session.createdAt ? now - session.createdAt : Number.POSITIVE_INFINITY;
+        if (sessionAge < delayMs) continue;
+
+        if (session.messageCount < MIN_PROMPTS_FOR_FIRST_SUMMARY) continue;
+
+        const existing = state.paneSummaries[terminalId];
+        const book = bookkeeping.current.get(terminalId);
+
+        // First-ever summary for this pane.
+        if (!existing || existing.status === 'idle') {
+          if (book && now - book.lastFiredAt < REFRESH_COOLDOWN_MS) continue;
+          bookkeeping.current.set(terminalId, {
+            lastFiredAt: now,
+            lastSummarisedMessageCount: book?.lastSummarisedMessageCount ?? 0,
+          });
+          state.requestPaneSummary(terminalId);
+          continue;
+        }
+
+        // Already pending — leave it alone.
+        if (existing.status === 'pending') continue;
+
+        // Permanent state for this provider — never retry, BUT only when
+        // the unavailable marker is for this pane's *current* session.
+        // If the pane was re-linked to a different session, the stale
+        // unavailable summary should not block a fresh attempt.
+        if (existing.status === 'unavailable' && existing.sessionId === session.id) continue;
+        if (existing.status === 'unavailable') {
+          // Stale unavailable from a prior session — clear and try fresh.
+          state.clearPaneSummary(terminalId);
+        }
+
+        // Successful previous summary — refresh on big growth.
+        if (existing.status === 'ready') {
+          const lastCount = book?.lastSummarisedMessageCount ?? 0;
+          const growth = session.messageCount - lastCount;
+          if (growth >= MESSAGE_DELTA_FOR_REFRESH
+              && (!book || now - book.lastFiredAt >= REFRESH_COOLDOWN_MS)) {
+            bookkeeping.current.set(terminalId, {
+              lastFiredAt: now,
+              lastSummarisedMessageCount: session.messageCount,
+            });
+            state.requestPaneSummary(terminalId);
+          }
+          continue;
+        }
+
+        // status === 'error' — retry after one cooldown, not on every tick.
+        if (existing.status === 'error') {
+          if (book && now - book.lastFiredAt < REFRESH_COOLDOWN_MS) continue;
+          bookkeeping.current.set(terminalId, {
+            lastFiredAt: now,
+            lastSummarisedMessageCount: book?.lastSummarisedMessageCount ?? 0,
+          });
+          state.requestPaneSummary(terminalId);
+        }
+      }
+    };
+
+    // Run once shortly after mount so newly-created panes don't wait
+    // a full tick interval.
+    const initial = setTimeout(evaluate, 5_000);
+    const tick = setInterval(evaluate, TICK_INTERVAL_MS);
+
+    // When a summary lands, update the bookkeeping snapshot so the
+    // delta check works correctly next tick.
+    const unsub = useTerminalStore.subscribe((state, prev) => {
+      if (state.paneSummaries === prev.paneSummaries) return;
+      for (const [terminalId, summary] of Object.entries(state.paneSummaries)) {
+        if (summary.status !== 'ready') continue;
+        const linked = state.terminals.get(terminalId);
+        if (!linked || !linked.aiSessionId) continue;
+        const session = state.copilotSessions.find((s) => s.id === linked.aiSessionId);
+        if (!session) continue;
+        const existing = bookkeeping.current.get(terminalId) ?? {
+          lastFiredAt: 0,
+          lastSummarisedMessageCount: 0,
+        };
+        existing.lastSummarisedMessageCount = session.messageCount;
+        bookkeeping.current.set(terminalId, existing);
+      }
+    });
+
+    // Drop bookkeeping entries for closed panes.
+    const cleanupUnsub = useTerminalStore.subscribe((state, prev) => {
+      if (state.terminals === prev.terminals) return;
+      for (const id of bookkeeping.current.keys()) {
+        if (!state.terminals.has(id)) bookkeeping.current.delete(id);
+      }
+    });
+
+    return () => {
+      clearTimeout(initial);
+      clearInterval(tick);
+      unsub();
+      cleanupUnsub();
+    };
+  }, []);
+}

--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -21,6 +21,12 @@ import { DEFAULT_WORKSPACE_ID, DEFAULT_WORKSPACE_NAME } from './types';
 import type { CopilotSessionSummary } from '../../shared/copilot-types';
 import type { DiffMode } from '../../shared/diff-types';
 import type { RepoWorktrees } from '../../shared/worktree-types';
+import type {
+  PaneSummary,
+  PaneSummaryResult,
+  PaneSummaryError,
+} from '../../shared/pane-summary-types';
+import { buildTranscriptVersion } from '../../shared/pane-summary-types';
 import { getAllTerminals, getTerminalEntry } from '../terminal-registry';
 import { confirmDialog } from '../components/AppDialog';
 
@@ -769,6 +775,10 @@ interface TerminalStore {
   // lives in main, so the underlying shell process is untouched. Soft
   // escape hatch for input-freezes (GH #101 / TASK-156).
   refreshGenerations: Record<string, number>;
+  /** AI-distilled 1-line pane summaries, keyed by TerminalId. In-memory
+   *  only — not persisted across restarts (see Task pane-summary plan).
+   *  Cleared per-pane on closeTerminal. */
+  paneSummaries: Record<TerminalId, PaneSummary>;
   selectedCopilotSessionId: string | null;
   // Prompts dialog state. Either terminalId (for the per-pane Ctrl+Shift+K
   // shortcut) or sessionId (for opening from the session summary popover).
@@ -968,6 +978,18 @@ interface TerminalStore {
   updateClaudeCodeSession: (session: CopilotSessionSummary) => void;
   removeClaudeCodeSession: (sessionId: string) => void;
   setSessionNameOverride: (sessionId: string, name: string) => void;
+  // ── Pane summary actions (Task pane-summary) ──────────────────────
+  /** Fire-and-forget request to the main summarizer service for the
+   *  pane's linked AI session. Marks the pane status as 'pending' and
+   *  short-circuits when an in-flight request for the same
+   *  transcriptVersion already exists (unless force=true). */
+  requestPaneSummary: (terminalId: TerminalId, opts?: { force?: boolean }) => void;
+  /** Apply a result that arrived from main via IPC. */
+  applyPaneSummaryResult: (result: PaneSummaryResult) => void;
+  /** Apply an error that arrived from main via IPC. */
+  applyPaneSummaryError: (err: PaneSummaryError) => void;
+  /** Drop the summary entry for a closed pane. */
+  clearPaneSummary: (terminalId: TerminalId) => void;
   setSessionLifecycle: (sessionId: string, lifecycle: import('../../shared/copilot-types').SessionLifecycle) => void;
   // Move stale AI sessions to the 'old' (Archived) lifecycle on app start
   // so the Active tab stays scrollable. Skips pinned sessions and any
@@ -1125,6 +1147,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
   copilotSearching: false,
   copilotSqliteActive: false,
   refreshGenerations: {},
+  paneSummaries: {},
   selectedCopilotSessionId: null,
   tabGroups: new Map(),
   markdownPreview: null,
@@ -1406,6 +1429,10 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     const newTerminals = new Map(terminals);
     newTerminals.delete(id);
 
+    // Drop any in-memory pane summary tied to this terminal.
+    const newPaneSummaries = { ...get().paneSummaries };
+    delete newPaneSummaries[id];
+
     let newRoot = layout.tilingRoot;
     let newFloating = layout.floatingPanels;
 
@@ -1448,6 +1475,7 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       focusedTerminalId: newFocus,
       preGridRoot: newPreGridRoot,
       closedTerminals: newClosedTerminals,
+      paneSummaries: newPaneSummaries,
     });
 
     // After React processes the layout change, force-focus the new terminal.
@@ -4302,6 +4330,164 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     try {
       (window.terminalAPI as any).syncSessionNameOverrides?.(get().sessionNameOverrides);
     } catch { /* ignore - main side falls back to summary if not synced */ }
+  },
+
+  // ── Pane summary actions (Task pane-summary) ────────────────────────
+  requestPaneSummary: (terminalId: TerminalId, opts?: { force?: boolean }) => {
+    const state = get();
+    const terminal = state.terminals.get(terminalId);
+    if (!terminal || !terminal.aiSessionId) return;
+
+    // Look up the live session to get provider + transcriptVersion. We
+    // refuse to request if the linked session has gone away — the
+    // service would only fail anyway.
+    let provider: 'copilot' | 'claude-code' | null = null;
+    let session: CopilotSessionSummary | undefined = state.copilotSessions.find((s) => s.id === terminal.aiSessionId);
+    if (session) provider = 'copilot';
+    else {
+      session = state.claudeCodeSessions.find((s) => s.id === terminal.aiSessionId);
+      if (session) provider = 'claude-code';
+    }
+    if (!session || !provider) return;
+
+    const transcriptVersion = buildTranscriptVersion(session.messageCount, session.latestPromptTime);
+    const existing = state.paneSummaries[terminalId];
+
+    // Short-circuit: same transcriptVersion already ready or pending, and
+    // caller didn't force a refresh.
+    if (!opts?.force && existing
+      && existing.sessionId === session.id
+      && existing.transcriptVersion === transcriptVersion
+      && (existing.status === 'pending' || existing.status === 'ready')
+    ) {
+      return;
+    }
+
+    // Mark pending so the UI can show a shimmer before the IPC round-trip.
+    set((s) => ({
+      paneSummaries: {
+        ...s.paneSummaries,
+        [terminalId]: {
+          provider,
+          sessionId: session!.id,
+          transcriptVersion,
+          text: existing?.text ?? '',
+          generatedAt: existing?.generatedAt ?? 0,
+          status: 'pending',
+          lastError: undefined,
+        },
+      },
+    }));
+
+    try {
+      window.terminalAPI.requestPaneSummary?.({
+        terminalId,
+        sessionId: session.id,
+        provider,
+        force: opts?.force,
+        wslDistro: terminal.wslDistro,
+      });
+
+      // Safety net: the service has 60s timeout × (1 + MAX_RETRIES=1) = 120s
+      // worst case. Give it 150s before declaring the renderer state stuck
+      // — that way a slow-but-eventually-successful spawn still wins.
+      const sessionIdSnapshot = session.id;
+      const transcriptVersionSnapshot = transcriptVersion;
+      setTimeout(() => {
+        const cur = get().paneSummaries[terminalId];
+        if (
+          cur
+          && cur.status === 'pending'
+          && cur.sessionId === sessionIdSnapshot
+          && cur.transcriptVersion === transcriptVersionSnapshot
+        ) {
+          set((s) => ({
+            paneSummaries: {
+              ...s.paneSummaries,
+              [terminalId]: {
+                ...s.paneSummaries[terminalId]!,
+                status: 'error',
+                lastError: 'no response from main process; check Copilot CLI is installed',
+              },
+            },
+          }));
+        }
+      }, 150_000);
+    } catch {
+      // Preload bridge missing (older build) — surface gracefully.
+      set((s) => ({
+        paneSummaries: {
+          ...s.paneSummaries,
+          [terminalId]: {
+            ...s.paneSummaries[terminalId]!,
+            status: 'error',
+            lastError: 'preload bridge unavailable',
+          },
+        },
+      }));
+    }
+  },
+
+  applyPaneSummaryResult: (result: PaneSummaryResult) => {
+    set((s) => {
+      // Only accept if the pane still exists and is still linked to the
+      // session this summary was generated for. Avoids racing with a
+      // pane that closed or got re-linked to a different session during
+      // the spawn.
+      const t = s.terminals.get(result.terminalId);
+      if (!t || t.aiSessionId !== result.sessionId) return s;
+      return {
+        paneSummaries: {
+          ...s.paneSummaries,
+          [result.terminalId]: {
+            provider: result.provider,
+            sessionId: result.sessionId,
+            transcriptVersion: result.transcriptVersion,
+            text: result.text,
+            generatedAt: result.generatedAt,
+            status: 'ready',
+            lastError: undefined,
+          },
+        },
+      };
+    });
+  },
+
+  applyPaneSummaryError: (err: PaneSummaryError) => {
+    set((s) => {
+      // Reject error if the pane no longer exists OR was re-linked to a
+      // different session since this request was filed. Otherwise an old
+      // unavailable/error from a session we just unlinked from would
+      // poison the new linkage forever.
+      const t = s.terminals.get(err.terminalId);
+      if (!t || t.aiSessionId !== err.sessionId) return s;
+      const existing = s.paneSummaries[err.terminalId];
+      return {
+        paneSummaries: {
+          ...s.paneSummaries,
+          [err.terminalId]: {
+            provider: err.provider,
+            sessionId: err.sessionId,
+            transcriptVersion: existing?.transcriptVersion ?? '',
+            // Retain prior good text on error so the tooltip doesn't go
+            // blank just because a refresh failed.
+            text: existing?.text ?? '',
+            generatedAt: existing?.generatedAt ?? 0,
+            status: err.unavailable ? 'unavailable' : 'error',
+            lastError: err.message,
+          },
+        },
+      };
+    });
+  },
+
+  clearPaneSummary: (terminalId: TerminalId) => {
+    set((s) => {
+      if (!(terminalId in s.paneSummaries)) return s;
+      const next = { ...s.paneSummaries };
+      delete next[terminalId];
+      return { paneSummaries: next };
+    });
   },
 
   setSessionLifecycle: (sessionId: string, lifecycle: import('../../shared/copilot-types').SessionLifecycle) => {

--- a/src/renderer/state/types.ts
+++ b/src/renderer/state/types.ts
@@ -201,6 +201,8 @@ export interface TerminalConfig {
 
 export type BackgroundMaterial = 'none' | 'auto' | 'mica' | 'acrylic' | 'tabbed';
 
+import type { PaneSummaryConfig } from '../../shared/pane-summary-types';
+
 export interface AppConfig {
   shells: ShellProfile[];
   defaultShellId: string;
@@ -217,6 +219,8 @@ export interface AppConfig {
   hideTabCloseButtons?: boolean;
   backgroundMaterial?: BackgroundMaterial;
   backgroundOpacity?: number; // 0.0–1.0, default 0.8
+  /** AI-distilled 1-line pane summary feature; see PaneSummaryConfig. */
+  paneSummary?: PaneSummaryConfig;
 }
 
 // ── Drag & drop ──────────────────────────────────────────────────────

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -6061,3 +6061,62 @@ select.settings-input {
     opacity: 1;
   }
 }
+
+/* ── Pane summary tooltip (Task pane-summary) ──────────────────────
+   Hover tooltip shown over tab/pane titles displaying the AI-distilled
+   1-sentence summary of what the user is doing in that pane. */
+.pane-summary-tooltip {
+  font-size: 12px;
+  line-height: 1.45;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 8px 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  /* Animate-in: keeps a quick hover from feeling jarring. */
+  animation: pane-summary-tooltip-fade-in 120ms ease-out;
+  user-select: none;
+}
+
+@keyframes pane-summary-tooltip-fade-in {
+  from { opacity: 0; transform: translateY(-2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.pane-summary-tooltip-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pane-summary-tooltip-text {
+  white-space: normal;
+  word-break: break-word;
+}
+
+.pane-summary-tooltip-muted {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.pane-summary-tooltip-meta {
+  font-size: 11px;
+  color: var(--text-secondary);
+  opacity: 0.8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pane-summary-tooltip {
+    animation: none;
+  }
+}
+
+/* Layout wrapper for the row of label/mode/ai-status pills inside the
+   terminals popover. */
+.terminal-list-popover-item-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -87,6 +87,10 @@ export const IPC = {
   KEYBINDINGS_OPEN_FILE: 'keybindings:openFile',
   KEYBINDINGS_RESET: 'keybindings:reset',
   KEYBINDINGS_CHANGED: 'keybindings:changed',
+  // ── Pane summary (AI-distilled 1-liner per pane) ───────────────────
+  PANE_SUMMARY_REQUEST: 'paneSummary:request',
+  PANE_SUMMARY_RESULT: 'paneSummary:result',
+  PANE_SUMMARY_ERROR: 'paneSummary:error',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/src/shared/pane-summary-types.ts
+++ b/src/shared/pane-summary-types.ts
@@ -1,0 +1,109 @@
+import type { SessionProvider } from './copilot-types';
+
+// ── Pane summary feature ────────────────────────────────────────────
+// AI-distilled one-sentence summary of "what is the user doing in this
+// pane right now". Sourced by spawning a sandboxed, non-interactive
+// summarizer invocation of the same AI CLI that owns the pane (today:
+// Copilot only; Claude deferred to v2). The result is surfaced on hover
+// of the tab/pane title and via the pane ⋯ menu (Refresh / Copy).
+//
+// Lifetime is in-memory only — not persisted across restarts. The user
+// asked for "refresh per session", and persisting would also imply
+// stale summaries across CLI / model upgrades.
+
+/** Name prefix written to ~/.copilot/session-state/<id>/workspace.yaml's
+ *  `name:` field for every summarizer invocation. The Copilot session
+ *  monitor (src/main/copilot-session-monitor.ts) filters these out so
+ *  they never appear in the AI Sessions panel. */
+export const SUMMARIZER_SESSION_NAME_PREFIX = 'tmax-summarizer:';
+
+/** Returns true when an AI session's name was written by our own
+ *  summarizer spawn. Used by the session monitor to skip them and by
+ *  tests to recognise spike artifacts. */
+export function isSummarizerSessionName(name: string | undefined | null): boolean {
+  return !!name && name.startsWith(SUMMARIZER_SESSION_NAME_PREFIX);
+}
+
+/** Compact identity for the source AI session at the time of a
+ *  summary. Two AI sessions with the same {provider, sessionId,
+ *  transcriptVersion} produce the same summary, so the service uses
+ *  this triple as its cache key (de-dups two panes pointing at one
+ *  session and short-circuits re-requests until the session moves on).
+ *
+ *  transcriptVersion is derived from `messageCount + ":" + latestPromptTime`,
+ *  both already exposed on CopilotSessionSummary. We avoid file mtime
+ *  because JSONL writes can lag behind the in-memory session state by
+ *  hundreds of ms and would produce spurious cache invalidations. */
+export function buildTranscriptVersion(messageCount: number, latestPromptTime: number | undefined): string {
+  return `${messageCount}:${latestPromptTime ?? 0}`;
+}
+
+export type PaneSummaryStatus = 'idle' | 'pending' | 'ready' | 'error' | 'unavailable';
+
+/** Stored per TerminalId in the renderer store (paneSummaries map). */
+export interface PaneSummary {
+  /** Provider that produced this summary (or would have, for 'error'/'pending'). */
+  provider: SessionProvider;
+  /** AI session id this summary was distilled from. */
+  sessionId: string;
+  /** Identity of the transcript at generation time (see buildTranscriptVersion). */
+  transcriptVersion: string;
+  /** The 1-sentence summary text, or '' while pending / on error. Validators
+   *  ensure this is short, single-line, no leading/trailing quotes or preamble. */
+  text: string;
+  /** ms-since-epoch when text was written. 0 for pending/error. */
+  generatedAt: number;
+  status: PaneSummaryStatus;
+  /** Short error label suitable for tooltips (e.g. "copilot CLI not found",
+   *  "timed out after 60s", "output rejected by validator"). Never the
+   *  raw transcript or stderr body. */
+  lastError?: string;
+}
+
+/** Renderer → main: ask for a summary for a specific pane. */
+export interface PaneSummaryRequest {
+  terminalId: string;
+  sessionId: string;
+  provider: SessionProvider;
+  /** When true, bypass cache and the auto-trigger gate (used by the
+   *  `Refresh Summary` menu item). */
+  force?: boolean;
+  /** Optional WSL distro the summarizer should be spawned inside. */
+  wslDistro?: string;
+}
+
+/** Main → renderer: a summary is ready. */
+export interface PaneSummaryResult {
+  terminalId: string;
+  sessionId: string;
+  provider: SessionProvider;
+  transcriptVersion: string;
+  text: string;
+  generatedAt: number;
+}
+
+/** Main → renderer: summary attempt failed. */
+export interface PaneSummaryError {
+  terminalId: string;
+  sessionId: string;
+  provider: SessionProvider;
+  /** Short, user-presentable label. NEVER includes transcript bodies. */
+  message: string;
+  /** When true the provider is gated off entirely for this session — the
+   *  hook should set status='unavailable' and stop retrying. */
+  unavailable?: boolean;
+}
+
+/** AppConfig.paneSummary shape — shared between main config-store and
+ *  renderer types. Defaults: enabled=true, delayMs=5 minutes. */
+export interface PaneSummaryConfig {
+  enabled: boolean;
+  /** How long after a session starts (ms) before the first auto-summary
+   *  fires. Also gated on messageCount ≥ 3 inside the renderer hook. */
+  delayMs: number;
+}
+
+export const DEFAULT_PANE_SUMMARY_CONFIG: PaneSummaryConfig = {
+  enabled: true,
+  delayMs: 5 * 60 * 1000,
+};

--- a/tests/e2e/pane-summary.spec.ts
+++ b/tests/e2e/pane-summary.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test';
+import { validateAndCleanSummary } from '../../src/main/pane-summary-service';
+import {
+  buildTranscriptVersion,
+  isSummarizerSessionName,
+  SUMMARIZER_SESSION_NAME_PREFIX,
+  DEFAULT_PANE_SUMMARY_CONFIG,
+} from '../../src/shared/pane-summary-types';
+
+// Task pane-summary unit tests.
+//
+// These cover the deterministic, side-effect-free pieces of the
+// pane-summary feature: the output validator, the transcript-version
+// helper, and the summarizer-session prefix gate. The spawning + IPC
+// layer is covered by a smoke check in the rubber-duck pass; here we
+// focus on the pure logic that every code path depends on.
+
+test.describe('pane-summary: validateAndCleanSummary', () => {
+  test('accepts a clean one-sentence summary', () => {
+    const out = validateAndCleanSummary('Refactoring the WSL path utilities and adding tests.');
+    expect(out).toBe('Refactoring the WSL path utilities and adding tests.');
+  });
+
+  test('rejects empty / whitespace-only input', () => {
+    expect(validateAndCleanSummary('')).toBeNull();
+    expect(validateAndCleanSummary('   \n\n  ')).toBeNull();
+  });
+
+  test('strips surrounding double quotes', () => {
+    expect(validateAndCleanSummary('"Fixing the build."')).toBe('Fixing the build.');
+  });
+
+  test('strips smart quotes', () => {
+    expect(validateAndCleanSummary('“Fixing the build.”')).toBe('Fixing the build.');
+  });
+
+  test('strips leading preamble like "Summary:"', () => {
+    expect(validateAndCleanSummary('Summary: Implementing pane hover tooltips.'))
+      .toBe('Implementing pane hover tooltips.');
+    expect(validateAndCleanSummary('TL;DR — fixing flaky tests.'))
+      .toBe('fixing flaky tests.');
+  });
+
+  test('drops content past the first non-empty line', () => {
+    const multi = 'Fixing tab focus.\nLine 2\nLine 3';
+    expect(validateAndCleanSummary(multi)).toBe('Fixing tab focus.');
+  });
+
+  test('strips code fences the model occasionally adds', () => {
+    const fenced = '```\nFixing the build.\n```';
+    expect(validateAndCleanSummary(fenced)).toBe('Fixing the build.');
+  });
+
+  test('caps the result to 25 words', () => {
+    const long = Array.from({ length: 40 }, (_v, i) => `word${i}`).join(' ');
+    const out = validateAndCleanSummary(long);
+    expect(out).not.toBeNull();
+    expect(out!.split(/\s+/).length).toBeLessThanOrEqual(25);
+  });
+
+  test('caps the result to 180 characters', () => {
+    const long = 'a'.repeat(500);
+    const out = validateAndCleanSummary(long);
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThanOrEqual(180 + 1); // +1 for terminal punctuation
+  });
+
+  test('rejects "session in progress" boilerplate', () => {
+    expect(validateAndCleanSummary('session in progress')).toBeNull();
+    expect(validateAndCleanSummary('Session in progress.')).toBeNull();
+  });
+
+  test('rejects "The user is …" boilerplate (model violating the prompt)', () => {
+    expect(validateAndCleanSummary('The user is working on tests')).toBeNull();
+  });
+
+  test('rejects too-short output', () => {
+    expect(validateAndCleanSummary('hi')).toBeNull();
+    expect(validateAndCleanSummary('done')).toBeNull();
+  });
+
+  test('adds terminal punctuation when missing', () => {
+    expect(validateAndCleanSummary('Refactoring authentication code'))
+      .toBe('Refactoring authentication code.');
+  });
+
+  test('leaves existing terminal punctuation alone', () => {
+    expect(validateAndCleanSummary('Refactoring authentication code!'))
+      .toBe('Refactoring authentication code!');
+  });
+
+  test('collapses interior whitespace', () => {
+    expect(validateAndCleanSummary('Fixing    the     build.'))
+      .toBe('Fixing the build.');
+  });
+});
+
+test.describe('pane-summary: buildTranscriptVersion', () => {
+  test('formats messageCount and latestPromptTime', () => {
+    expect(buildTranscriptVersion(3, 1_700_000_000_000)).toBe('3:1700000000000');
+  });
+
+  test('treats undefined latestPromptTime as 0', () => {
+    expect(buildTranscriptVersion(7, undefined)).toBe('7:0');
+  });
+
+  test('different inputs produce different versions', () => {
+    const a = buildTranscriptVersion(3, 1000);
+    const b = buildTranscriptVersion(4, 1000);
+    const c = buildTranscriptVersion(3, 2000);
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+    expect(b).not.toBe(c);
+  });
+});
+
+test.describe('pane-summary: isSummarizerSessionName', () => {
+  test('matches our prefix', () => {
+    expect(isSummarizerSessionName(`${SUMMARIZER_SESSION_NAME_PREFIX}deadbeef`)).toBe(true);
+  });
+
+  test('does not match unrelated names', () => {
+    expect(isSummarizerSessionName('Implementing tab summaries')).toBe(false);
+    expect(isSummarizerSessionName('summarizer-something')).toBe(false);
+    expect(isSummarizerSessionName(undefined)).toBe(false);
+    expect(isSummarizerSessionName(null)).toBe(false);
+    expect(isSummarizerSessionName('')).toBe(false);
+  });
+});
+
+test.describe('pane-summary: DEFAULT_PANE_SUMMARY_CONFIG', () => {
+  test('enabled by default', () => {
+    expect(DEFAULT_PANE_SUMMARY_CONFIG.enabled).toBe(true);
+  });
+
+  test('delay is 5 minutes by default', () => {
+    expect(DEFAULT_PANE_SUMMARY_CONFIG.delayMs).toBe(5 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## What

Adds an AI-generated one-line summary for each Copilot session, so users juggling several Copilot tabs in parallel can tell at a glance what each one is about.

The summary becomes the **tab title**, **pane header title**, and **sidebar session title**. The full text is shown as a **hover tooltip** on all three surfaces (CSS truncates with `…`). User renames always win — once you rename a session manually, that name sticks.

## Why

When working with multiple Copilot sessions side-by-side, tab titles like "Agency Copilot" don't help you remember which one was about debugging the API and which was planning a trip. A short, contextual summary makes parallel sessions usable.

## How it works

- A background service (`PaneSummaryService`, main process) spawns a sandboxed `copilot -p` child against the live session transcript and asks for a 1-sentence summary.
- The first summary runs automatically after **5 minutes of session activity** (configurable). Hovering a tab earlier kicks off an on-demand request.
- Cache is keyed by `(sessionId, transcriptVersion)` so the summarizer doesn't re-run unless the conversation has grown.
- Summarizer-spawned sessions are filtered out of every UI surface (prefixed name).

**v1 ships Copilot-only.** Claude Code wiring is deferred.

## User controls

- **Settings → Pane summary** — toggle (default on) + delay slider (default 5 min).
- Hover a tab/pane/sidebar entry → see full summary.
- Rename a session manually → your name takes precedence.

## Screenshots 

### Tabs titles : 
<img width="1727" height="1043" alt="image" src="https://github.com/user-attachments/assets/6a5e137f-d307-4b3b-bdd3-5ddc60d04a54" />


### Settings : 
<img width="675" height="235" alt="image" src="https://github.com/user-attachments/assets/9a30181b-1c5c-424b-98ac-dd3d119fff9f" />



## Files

| Area | Files |
| --- | --- |
| **Main process** | `src/main/pane-summary-service.ts` (queue, debounce, cache, retries, PATH resolution), `src/main/main.ts` (IPC + lifecycle), `src/main/copilot-session-monitor.ts` (filter summarizer sessions), `src/main/config-store.ts` |
| **Renderer state** | `src/renderer/state/terminal-store.ts` (`paneSummaries`, `requestPaneSummary`, `applyPaneSummaryResult`, `applyPaneSummaryError`), `src/renderer/state/types.ts` |
| **Renderer UI** | `TabBar.tsx`, `TerminalPanel.tsx`, `CopilotPanel.tsx` (title precedence + tooltips), `Settings.tsx` (toggle + slider) |
| **New components** | `HoverTooltip.tsx` (shared infrastructure), `PaneSummaryTooltip.tsx` (terminal-keyed), `SessionTitleTooltip.tsx` (session-keyed) |
| **Hook** | `src/renderer/hooks/useAutoPaneSummary.ts` |
| **IPC + types** | `src/shared/ipc-channels.ts`, `src/shared/pane-summary-types.ts`, `src/preload/preload.ts`, `src/renderer/App.tsx` |
| **Tests** | `tests/e2e/pane-summary.spec.ts` — 22 unit tests for validator, helpers, defaults |
| **Styles** | `src/renderer/styles/global.css` |

## Title precedence

```
sessionNameOverrides[aiSessionId] ?? aiSummary ?? terminal.title
```

`sessionNameOverrides` is the single source of truth for "user renamed this session". The `TerminalInstance` flags (`customTitle`, `aiAutoTitle`, `firstCommandTitle`) all get flipped by OSC sequences, the auto-link path, and first-command auto-rename, so they aren't reliable here.

## Reliability notes

- **PATH resolution**: when tmax is launched from Finder (macOS) the spawn env doesn't include user shell PATH. `resolveCopilotPath()` walks common install locations.
- **Renderer safety net**: 150s timeout protects against a stuck spawn.
- **Stale results**: `applyPaneSummaryResult` rejects results whose `sessionId` no longer matches the terminal's current link (race protection if the user re-links during a spawn).
- **Tooltip positioning**: wrapper uses `display:contents` to inherit the child's flex sizing; positioning walks into `firstElementChild` to get a real bounding rect (a `display:contents` element returns `0,0,0,0`).

## Verification

- `npx tsc --noEmit` — 32 errors, all pre-existing in unrelated areas (no new errors introduced).
- `npx playwright test pane-summary.spec.ts` — 22/22 pass.
- Manually verified in a multi-tab session: AI tab title swaps to summary, plain tabs untouched, hover tooltip positions correctly, rename pre-fills with the displayed title.

## Out of scope (follow-ups)

- Claude Code provider (v1 is Copilot-only).
- Surfacing the summary in any non-Copilot surface (e.g. workspace picker).
