### PR TITLE
Add Windows code signing via Azure Trusted Signing (OIDC)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,17 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    # id-token: write is required by azure/login OIDC. Harmless on non-Windows
+    # jobs since they don't call azure/login.
+    permissions:
+      contents: read
+      id-token: write
+
+    # Run Windows tag builds in the "release" environment so the federated
+    # credential subject (repo:InbarR/tmax:environment:release) matches and the
+    # OIDC exchange succeeds. Other jobs use no environment.
+    environment: ${{ (matrix.platform == 'win32' && startsWith(github.ref, 'refs/tags/v')) && 'release' || '' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,6 +52,26 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+
+      # Azure OIDC login for Windows code signing. Only runs on tagged release
+      # builds for win32; PR / branch builds and other platforms skip this and
+      # therefore skip signing too.
+      - name: Azure login (OIDC for Trusted Signing)
+        if: matrix.platform == 'win32' && startsWith(github.ref, 'refs/tags/v')
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      # Install the TrustedSigning PowerShell module used by scripts/windows-sign.cjs.
+      - name: Install TrustedSigning PowerShell module
+        if: matrix.platform == 'win32' && startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name TrustedSigning -RequiredVersion 0.5.3 -Scope CurrentUser -Force -AllowClobber
+          Get-Module -ListAvailable TrustedSigning | Format-Table Name, Version
 
       # Linux dependencies for Electron + native modules
       - name: Install Linux build dependencies
@@ -73,6 +104,13 @@ jobs:
         run: npm run build -- --arch=${{ matrix.arch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Sign Windows artifacts on tag builds. WINDOWS_SIGN=1 wires the hook
+          # in forge.config.ts; the TRUSTED_SIGNING_* vars are read by
+          # scripts/windows-sign.cjs and passed to Invoke-TrustedSigning.
+          WINDOWS_SIGN: ${{ (matrix.platform == 'win32' && startsWith(github.ref, 'refs/tags/v')) && '1' || '' }}
+          TRUSTED_SIGNING_ENDPOINT: ${{ vars.TRUSTED_SIGNING_ENDPOINT }}
+          TRUSTED_SIGNING_ACCOUNT: ${{ vars.TRUSTED_SIGNING_ACCOUNT }}
+          TRUSTED_SIGNING_PROFILE: ${{ vars.TRUSTED_SIGNING_PROFILE }}
 
       # Ad-hoc sign macOS app so it can run without Gatekeeper errors
       - name: Ad-hoc sign macOS app

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -6,6 +6,14 @@ import { MakerDeb } from "@electron-forge/maker-deb";
 import { MakerRpm } from "@electron-forge/maker-rpm";
 import { MakerDMG } from "@electron-forge/maker-dmg";
 
+// Windows code signing via Azure Trusted Signing. Only enabled when
+// WINDOWS_SIGN=1 (set in CI for tagged release builds), so local and PR
+// builds never try to sign. The hook signs the packaged app binaries
+// (during `package`) and the Squirrel Setup.exe (during `make`).
+const windowsSign = process.env.WINDOWS_SIGN === '1'
+  ? { hookModulePath: require('path').resolve(__dirname, 'scripts', 'windows-sign.cjs') }
+  : undefined;
+
 const config: ForgeConfig = {
   outDir: process.env.FORGE_OUT_DIR || 'out',
   hooks: {
@@ -107,10 +115,11 @@ const config: ForgeConfig = {
     name: "tmax",
     executableName: "tmax",
     icon: "./assets/icon",
+    ...(windowsSign ? { windowsSign } : {}),
   },
   makers: [
     // Windows
-    new MakerSquirrel({ authors: "tmax", description: "Powerful multi-terminal app", setupIcon: "./assets/icon.ico", iconUrl: "https://raw.githubusercontent.com/InbarR/tmax/main/assets/icon.ico" }),
+    new MakerSquirrel({ authors: "tmax", description: "Powerful multi-terminal app", setupIcon: "./assets/icon.ico", iconUrl: "https://raw.githubusercontent.com/InbarR/tmax/main/assets/icon.ico", ...(windowsSign ? { windowsSign } : {}) }),
     // macOS
     new MakerDMG({ format: "ULFO" }),
     // Linux

--- a/scripts/windows-sign.cjs
+++ b/scripts/windows-sign.cjs
@@ -1,0 +1,49 @@
+// @electron/windows-sign hook for Azure Trusted Signing.
+//
+// electron-forge calls this once per file it wants to sign: the packaged
+// app binaries during `package`, and the Squirrel Setup.exe during `make`.
+// We sign each via the official `TrustedSigning` PowerShell module
+// (Invoke-TrustedSigning), which wraps signtool + the Azure.CodeSigning
+// dlib and authenticates with the ambient Azure credential established by
+// `azure/login` (OIDC) in CI.
+//
+// Configuration comes from the environment so nothing sensitive lives in
+// the repo:
+//   TRUSTED_SIGNING_ENDPOINT  e.g. https://weu.codesigning.azure.net/
+//   TRUSTED_SIGNING_ACCOUNT   the code signing account name
+//   TRUSTED_SIGNING_PROFILE   the certificate profile name
+//
+// This hook is only wired up when WINDOWS_SIGN=1 (see forge.config.ts), so
+// local/dev builds never attempt to sign.
+const { execFileSync } = require('node:child_process');
+
+module.exports = async function windowsSign(filePath) {
+  const endpoint = process.env.TRUSTED_SIGNING_ENDPOINT;
+  const account = process.env.TRUSTED_SIGNING_ACCOUNT;
+  const profile = process.env.TRUSTED_SIGNING_PROFILE;
+
+  if (!endpoint || !account || !profile) {
+    throw new Error(
+      'Trusted Signing not configured: set TRUSTED_SIGNING_ENDPOINT, ' +
+      'TRUSTED_SIGNING_ACCOUNT and TRUSTED_SIGNING_PROFILE.',
+    );
+  }
+
+  // Build the Invoke-TrustedSigning call. Single-quote the file path so
+  // PowerShell treats it literally (paths can contain spaces).
+  const psCommand = [
+    'Invoke-TrustedSigning',
+    `-Endpoint '${endpoint}'`,
+    `-CodeSigningAccountName '${account}'`,
+    `-CertificateProfileName '${profile}'`,
+    `-Files '${filePath.replace(/'/g, "''")}'`,
+    '-FileDigest SHA256',
+    "-TimestampRfc3161 'http://timestamp.acs.microsoft.com'",
+    '-TimestampDigest SHA256',
+  ].join(' ');
+
+  console.log(`[windows-sign] Signing ${filePath}`);
+  execFileSync('pwsh', ['-NoProfile', '-NonInteractive', '-Command', psCommand], {
+    stdio: 'inherit',
+  });
+};


### PR DESCRIPTION
## Windows code signing via Azure Trusted Signing (OIDC)

Signs Windows artifacts on **tagged release builds** so the downloaded `Setup.exe`, the installed `tmax.exe`, and the auto-update nupkg are all Authenticode-signed - removing SmartScreen / unknown-publisher warnings.

### Changes
- `scripts/windows-sign.cjs` - `@electron/windows-sign` hook that signs each file via the `TrustedSigning` PowerShell module (`Invoke-TrustedSigning`), authenticated by the ambient Azure credential from `azure/login` (OIDC).
- `forge.config.ts` - wires the hook into `packagerConfig` (app binaries) and `MakerSquirrel` (Setup.exe), gated on `WINDOWS_SIGN=1` so local/PR builds never sign.
- `.github/workflows/build.yml` - **(added separately via web editor - fine-grained PAT cannot push workflow files)** id-token permission + `release` environment, OIDC login, TrustedSigning install, and `WINDOWS_SIGN`/`TRUSTED_SIGNING_*` env, all gated to win32 tag builds.

Windows only; macOS still needs a separate Apple Developer certificate.

### Required repo configuration (not in code)
- Variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `TRUSTED_SIGNING_ENDPOINT`, `TRUSTED_SIGNING_ACCOUNT`, `TRUSTED_SIGNING_PROFILE`
- A `release` environment (no required-reviewer / branch-restriction rules)
- Federated credential subject `repo:InbarR/tmax:environment:release` + the "Trusted Signing Certificate Profile Signer" role on the app registration

### Validation
Push a prerelease tag (e.g. `v1.9.2-rc1`) - signing runs on any `v*` tag; the rc suffix keeps it out of stable auto-update.