### PR TITLE
fix(stats): blank chart on Week+delta and rank top-5 by activity in window

### DIFF
--- a/docs/stats-5d5f6800d035.html
+++ b/docs/stats-5d5f6800d035.html
@@ -400,8 +400,24 @@ function renderTimeline() {
 
   // When stacking by platform there are only 3-4 buckets so no top-N slicing
   // is needed. When stacking by release, cap at 5 for legend readability.
+  // Rank by *activity in the visible window* (sum of deltas, or last-first in
+  // cumulative mode — which is the same number). Sorting by `last.count`
+  // would always favor the oldest releases since they've had the longest to
+  // accumulate downloads, so newer releases (e.g. v1.9.x) could never crack
+  // the top 5 even when they're driving most of the current install volume.
+  // This also "just works" when the user drag-zooms into a sub-range.
+  const activity = (points) => {
+    if (!points.length) return 0;
+    if (timelineMode === 'delta') {
+      let s = 0;
+      for (const p of points) s += p.count;
+      return s;
+    }
+    // cumulative: activity within window is end - start
+    return Math.max(0, points[points.length - 1].count - points[0].count);
+  };
   const ranked = Array.from(series.entries())
-    .sort(([, a], [, b]) => (b.at(-1)?.count ?? 0) - (a.at(-1)?.count ?? 0))
+    .sort(([, a], [, b]) => activity(b) - activity(a))
     .slice(0, timelineStack === 'platform' ? 10 : 5);
 
   const pad = { top: 20, right: 16, bottom: 80, left: 40 };
@@ -564,7 +580,7 @@ function renderTimeline() {
     else spanLabel = ` Span: ${Math.round(minutes / (60 * 24) * 10) / 10} days.`;
   }
   const bucketCountLabel = timelineInterval === 'all' ? '' : ` → ${bucketed.length} bar(s) ${intervalLabel}`;
-  document.getElementById('timelineNote').textContent = `${timelineHistory.length} snapshot(s)${bucketCountLabel}, ${modeLabel}. Top 5 releases.${spanLabel}${hintIfSingle}`;
+  document.getElementById('timelineNote').textContent = `${timelineHistory.length} snapshot(s)${bucketCountLabel}, ${modeLabel}. Top 5 releases by activity in window.${spanLabel}${hintIfSingle}`;
 }
 
 function renderDiff() {

--- a/docs/stats-5d5f6800d035.html
+++ b/docs/stats-5d5f6800d035.html
@@ -387,14 +387,21 @@ function renderTimeline() {
         const prev = points[i - 1].count;
         deltas.push({ t: points[i].t, count: Math.max(0, points[i].count - prev) });
       }
-      series.set(tag, deltas);
+      // A series with a single bucket has no "previous" to subtract from, so
+      // deltas comes out empty. Drop it — otherwise the sort comparator below
+      // dereferences points[length-1].count on [] and throws a TypeError that
+      // aborts the entire render (blank chart + stale footer note). This is
+      // why Week + New per interval looked broken: top releases like the
+      // newest version often live entirely in one weekly bucket.
+      if (deltas.length) series.set(tag, deltas);
+      else series.delete(tag);
     }
   }
 
   // When stacking by platform there are only 3-4 buckets so no top-N slicing
   // is needed. When stacking by release, cap at 5 for legend readability.
   const ranked = Array.from(series.entries())
-    .sort(([, a], [, b]) => (b[b.length - 1].count) - (a[a.length - 1].count))
+    .sort(([, a], [, b]) => (b.at(-1)?.count ?? 0) - (a.at(-1)?.count ?? 0))
     .slice(0, timelineStack === 'platform' ? 10 : 5);
 
   const pad = { top: 20, right: 16, bottom: 80, left: 40 };


### PR DESCRIPTION
## Problem 1 — blank chart on Week + New per interval

Selecting **Week** grouping + **New per interval** rendered a completely blank chart with a stale footer note. Cause: weekly bucketing leaves some top releases with a single bucket; the cumulative->delta conversion drops the first point of every series, so those collapse to `[]`. The top-N sort comparator then dereferences `points[length-1].count` on an empty array, throws a TypeError, and aborts `renderTimeline` before it can draw or refresh the footer.

**Fix:** drop empty series after delta conversion and guard the sort with optional chaining.

## Problem 2 — newest releases (v1.9.x) never appear in the chart

The top-5 picker sorted by `last.count`, which in cumulative mode is the all-time download total. Older releases have had more time to accumulate, so the top 5 was permanently dominated by v1.5.x-v1.7.x — v1.9.x couldn't crack it even when it was driving most current install volume.

**Fix:** rank by *activity in the visible window* (sum of deltas in delta mode, `last - first` in cumulative mode — equivalent numbers). Also makes the top 5 meaningful when drag-zoomed into a sub-range. Footer note updated to `Top 5 releases by activity in window`.

## Test plan
- Open `docs/stats-5d5f6800d035.html`, toggle Week + New per interval → chart renders, footer note updates.
- Other combinations (Day/Hour/All x Cumulative/Delta x Release/Platform) still render as before.
- Newest release now appears in the legend when it has recent activity.