### PR TITLE
fix(transcript): scroll to latest message on first open

### DIFF
--- a/src/renderer/components/TranscriptPanel.tsx
+++ b/src/renderer/components/TranscriptPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import React, { useEffect, useLayoutEffect, useState, useMemo, useRef, useCallback } from 'react';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { useTerminalStore } from '../state/terminal-store';
@@ -87,6 +87,10 @@ const TranscriptPanel: React.FC = () => {
   const panelRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const sigRef = useRef<string>('');
+  // Tracks which session id has had its initial scroll-to-bottom done. We jump
+  // to the latest message the first time a session's messages land in the DOM,
+  // so opening the transcript on a long chat doesn't dump you at the very top.
+  const initialScrolledForRef = useRef<string | null>(null);
   const close = useCallback(() => useTerminalStore.setState({ transcriptOpen: false }), []);
 
   // ── Search state ──────────────────────────────────────────────────
@@ -116,6 +120,7 @@ const TranscriptPanel: React.FC = () => {
     if (!open || !aiSessionId) { setMsgs(null); return; }
     let cancelled = false;
     sigRef.current = '';
+    initialScrolledForRef.current = null;
     setMsgs(null);
 
     const fetchOnce = (initial: boolean) => {
@@ -137,12 +142,14 @@ const TranscriptPanel: React.FC = () => {
               return;
             }
           }
-          const wasAtBottom = initial || atBottom();
+          const wasAtBottom = atBottom();
           sigRef.current = nextSig;
           setMsgs(next);
-          // Don't fight an active search: if the user is parked on a match,
-          // leave the scroll position where the search put it.
-          if (wasAtBottom && !searchActiveRef.current) scrollToBottom();
+          // On live updates, keep glueing to the bottom if the user was already
+          // there. The *initial* scroll-to-bottom is handled by the layout
+          // effect below, because at this point the new bubbles haven't been
+          // laid out yet and scrollHeight is still ~0 (which lands at the top).
+          if (!initial && wasAtBottom && !searchActiveRef.current) scrollToBottom();
         })
         .catch(() => { if (!cancelled && initial) setMsgs([]); });
     };
@@ -151,6 +158,18 @@ const TranscriptPanel: React.FC = () => {
     const timer = setInterval(() => fetchOnce(false), POLL_MS);
     return () => { cancelled = true; clearInterval(timer); };
   }, [open, aiSessionId, provider]);
+
+  // First-render jump: when a session's messages first hit the DOM, scroll the
+  // body to the bottom so opening the transcript on a long conversation lands
+  // on the most recent message instead of the very first one.
+  useLayoutEffect(() => {
+    if (!open || !aiSessionId || !msgs || msgs.length === 0) return;
+    if (initialScrolledForRef.current === aiSessionId) return;
+    const body = bodyRef.current;
+    if (!body) return;
+    body.scrollTop = body.scrollHeight;
+    initialScrolledForRef.current = aiSessionId;
+  }, [open, aiSessionId, msgs]);
 
   // Escape: close the search bar first if it's open, otherwise close the panel.
   useEffect(() => {


### PR DESCRIPTION
## What

Opening the **Transcript** panel (⌘+⌥+T / title-bar button) on a long conversation used to dump you at the very first message instead of jumping to the most recent one.

## Why

The initial fetch in `TranscriptPanel.tsx` called `scrollToBottom()` inside a single `requestAnimationFrame` immediately after `setMsgs(next)`. React hadn't actually rendered the new bubbles yet at that point, so `scrollHeight ≈ clientHeight` and `scrollTop = scrollHeight` effectively landed at the top. After the real render committed, the view stayed parked at message #1.

## How

- Added a `useLayoutEffect` keyed on `[open, aiSessionId, msgs]` that performs the first-render jump. It runs *after* layout (so `scrollHeight` is correct) but *before* paint (no visible flicker / jump).
- A new `initialScrolledForRef` tracks which session id has already had its initial scroll-to-bottom done, so the jump fires exactly once per session/open cycle and live polls don't re-trigger it.
- The existing live-poll "glue to bottom" behavior is preserved for follow-up updates when the user is already at the bottom; only the racy `initial ||` short-circuit in the fetch path was removed.

## Testing

Manual:
- Opened the transcript on a long (200+ message) session — now lands on the most recent message.
- Re-opened on the same session multiple times — consistent.
- Switched panes / followed focus to a different session — jumps to that session's latest message.
- Scrolled up, waited for a live update — view stays put (no auto-scroll). Scrolled back to bottom, new message arrived — glues to bottom. Both unchanged from before.
- Opened the search bar and parked on a hit — live updates don't yank the view away. Unchanged.

`npx tsc --noEmit` shows no new errors in the touched file (a handful of pre-existing errors in unrelated files are untouched).

<!-- BEGIN pr-telemetry -->
```
assistance: agentic-cli
type: bug
agent-tool: copilot-cli
agent-model: claude-opus-4.7
work-item: n/a
```
<!-- END pr-telemetry -->
