### PR TITLE
feat(terminal): copy-on-select (copy mouse selection to clipboard on mouse-up)

### DIFF
--- a/src/main/config-store.ts
+++ b/src/main/config-store.ts
@@ -44,6 +44,9 @@ export interface TerminalDefaults {
   // TASK-52: stitch CLI-rendered hard newlines + indent continuations
   // back into single paragraphs at copy time. Default true.
   smartUnwrapCopy?: boolean;
+  // Copy a mouse selection to the clipboard on mouse-up, no Ctrl+C needed.
+  // Default true.
+  copyOnSelect?: boolean;
 }
 
 export type BackgroundMaterial = 'none' | 'auto' | 'mica' | 'acrylic' | 'tabbed';
@@ -287,6 +290,7 @@ export const defaultConfig: AppConfig = {
     fontFamily: 'CaskaydiaCove Nerd Font, CaskaydiaCove NF, Cascadia Code, Consolas, monospace',
     scrollback: 50000,
     smartUnwrapCopy: true,
+    copyOnSelect: true,
   },
   copilotCommand: 'copilot',
   claudeCodeCommand: 'claude',

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -382,6 +382,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
   // TASK-52: read latest config in the copy handlers without rebuilding
   // the terminal. Updated by a small effect below.
   const smartUnwrapRef = useRef<boolean>(true);
+  // Mirrors config.terminal.copyOnSelect for the mouse handlers (which capture
+  // config at terminal-init time). When true, a mouse selection is written to
+  // the clipboard on mouse-up. Ctrl+C handling is untouched by this.
+  const copyOnSelectRef = useRef<boolean>(true);
   // TASK-261: snapshot of the text the user dragged over in a mouse-reporting
   // pane (Claude Code / TUI apps), where xterm makes no native selection.
   // Lifted to a component-scoped ref so BOTH the keyboard handler (Ctrl+C /
@@ -2508,6 +2512,18 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
             }
           }
         }
+        // Copy-on-select: when enabled, write the just-made selection to the
+        // clipboard on mouse-up so the user never needs Ctrl+C. Covers native
+        // xterm selections (drag / double / triple-click) and mouse-reporting
+        // TUI drags, where xterm makes no selection and we fall back to the
+        // buffer snapshot captured above (pendingTuiCopyRef). Gated on an actual
+        // selection gesture so a plain click never re-copies a stale snapshot.
+        // Ctrl+C / SIGINT handling is deliberately untouched.
+        if (copyOnSelectRef.current && (wasDrag || term.hasSelection())) {
+          const raw = term.hasSelection() ? term.getSelection() : (pendingTuiCopyRef.current ?? '');
+          const text = raw ? smartUnwrapForCopy(raw, smartUnwrapRef.current) : '';
+          if (text.trim()) window.terminalAPI.clipboardWrite(text);
+        }
         dragStartPos = null;
       }
     };
@@ -2736,6 +2752,11 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
   useEffect(() => {
     smartUnwrapRef.current = config?.terminal?.smartUnwrapCopy ?? true;
   }, [config?.terminal?.smartUnwrapCopy]);
+
+  // Keep copy-on-select in sync with the live config, same as smart-unwrap.
+  useEffect(() => {
+    copyOnSelectRef.current = config?.terminal?.copyOnSelect ?? true;
+  }, [config?.terminal?.copyOnSelect]);
 
   // React to fontSize and fontFamily changes
   const configFontFamily = config?.terminal?.fontFamily;

--- a/src/renderer/components/TerminalPanel.tsx
+++ b/src/renderer/components/TerminalPanel.tsx
@@ -2415,6 +2415,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
         const dx = e.clientX - dragStartPos.x;
         const dy = e.clientY - dragStartPos.y;
         const wasDrag = Math.sqrt(dx * dx + dy * dy) > DRAG_THRESHOLD;
+        // Text this gesture produced in a mouse-reporting TUI pane (xterm made
+        // no native selection). Set below when the drag yields a snapshot;
+        // used by copy-on-select so it never falls back to a stale ref.
+        let freshTuiSnapshot: string | null = null;
 
         // TASK-224: reliable single-click open for image-path links. xterm's
         // own link activation is hover-state dependent and misfires in AI CLI
@@ -2506,22 +2510,30 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ terminalId, floatTitleBar
             // we deliberately did not create a visible selection).
             const snapshot = readBufferRange(s, en).replace(/\s+$/u, '');
             if (snapshot) {
+              freshTuiSnapshot = snapshot;
               pendingTuiCopyRef.current = snapshot;
               if (pendingTuiCopyClearTimer) clearTimeout(pendingTuiCopyClearTimer);
               pendingTuiCopyClearTimer = setTimeout(clearPendingTuiCopy, 10000);
             }
           }
         }
-        // Copy-on-select: when enabled, write the just-made selection to the
-        // clipboard on mouse-up so the user never needs Ctrl+C. Covers native
-        // xterm selections (drag / double / triple-click) and mouse-reporting
-        // TUI drags, where xterm makes no selection and we fall back to the
-        // buffer snapshot captured above (pendingTuiCopyRef). Gated on an actual
-        // selection gesture so a plain click never re-copies a stale snapshot.
-        // Ctrl+C / SIGINT handling is deliberately untouched.
-        if (copyOnSelectRef.current && (wasDrag || term.hasSelection())) {
-          const raw = term.hasSelection() ? term.getSelection() : (pendingTuiCopyRef.current ?? '');
-          const text = raw ? smartUnwrapForCopy(raw, smartUnwrapRef.current) : '';
+        // Copy-on-select: copy the text THIS gesture produced to the clipboard
+        // on mouse-up, so no Ctrl+C is needed. Source is the fresh native
+        // selection or - in a mouse-reporting TUI pane, where xterm makes no
+        // selection - this gesture's buffer snapshot (never a stale ref, so a
+        // later empty drag can't re-copy old text). After copying a TUI
+        // snapshot we consume it, so a following Ctrl+C still sends ^C/SIGINT
+        // (closing the CLI) instead of being treated as a copy. Ctrl+C handling
+        // is otherwise untouched.
+        if (copyOnSelectRef.current) {
+          let copyText: string | null = null;
+          if (term.hasSelection()) {
+            copyText = term.getSelection();
+          } else if (freshTuiSnapshot) {
+            copyText = freshTuiSnapshot;
+            clearPendingTuiCopy();
+          }
+          const text = copyText ? smartUnwrapForCopy(copyText, smartUnwrapRef.current) : '';
           if (text.trim()) window.terminalAPI.clipboardWrite(text);
         }
         dragStartPos = null;

--- a/src/renderer/state/types.ts
+++ b/src/renderer/state/types.ts
@@ -207,6 +207,11 @@ export interface TerminalConfig {
   // hard newlines + 1-2 space continuation indents back into single
   // paragraphs. Disable if it ever clobbers code/structure.
   smartUnwrapCopy?: boolean;
+  // When true (default), selecting text with the mouse copies it to the
+  // clipboard immediately on mouse-up - no Ctrl+C needed. Covers native
+  // selections and mouse-reporting TUI drags (Copilot CLI / Claude Code).
+  // Ctrl+C behaviour is unchanged. Disable to only copy on an explicit gesture.
+  copyOnSelect?: boolean;
 }
 
 export type BackgroundMaterial = 'none' | 'auto' | 'mica' | 'acrylic' | 'tabbed';

--- a/tests/e2e/copy-on-select.spec.ts
+++ b/tests/e2e/copy-on-select.spec.ts
@@ -1,0 +1,123 @@
+// Copy-on-select: selecting text with the mouse writes it to the clipboard on
+// mouse-up, so no Ctrl+C / right-click is needed. This is additive - Ctrl+C
+// still sends ^C/SIGINT when there's nothing selected (covered by the TASK-261
+// specs). These tests drag with the real mouse and read the real clipboard,
+// asserting the copy happened with no follow-up copy gesture at all.
+import { test, expect, Page } from '@playwright/test';
+import { launchTmax } from './fixtures/launch';
+
+async function getClipboard(window: Page): Promise<string> {
+  return window.evaluate(() => (window as any).terminalAPI.clipboardRead());
+}
+
+async function setClipboard(window: Page, text: string): Promise<void> {
+  await window.evaluate((t: string) => (window as any).terminalAPI.clipboardWrite(t), text);
+}
+
+async function writeToTerminal(window: Page, text: string): Promise<void> {
+  await window.evaluate((t: string) => {
+    const id = (window as any).__terminalStore.getState().focusedTerminalId;
+    const entry = (window as any).__getTerminalEntry(id);
+    entry?.terminal.write(t);
+  }, text);
+}
+
+test('copy-on-select: native drag selection copies on mouse-up (no Ctrl+C, no right-click)', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForSelector('.terminal-panel', { timeout: 15_000 });
+    await window.waitForTimeout(800);
+
+    // Normal buffer, no mouse reporting: a drag makes a real xterm selection.
+    await writeToTerminal(window, '\r\nSELECT_ONSELECT_A\r\n');
+    await window.waitForTimeout(300);
+
+    await window.click('.terminal-panel .xterm-screen');
+    await window.waitForTimeout(200);
+
+    await setClipboard(window, '__STALE_ONSELECT_A__');
+    await window.waitForTimeout(100);
+
+    const coords = await window.evaluate(() => {
+      const id = (window as any).__terminalStore.getState().focusedTerminalId;
+      const entry = (window as any).__getTerminalEntry(id);
+      const term = entry?.terminal;
+      const dim = (term as any)._core?._renderService?.dimensions;
+      const cw = dim?.css?.cell?.width ?? dim?.actualCellWidth ?? 9;
+      const ch = dim?.css?.cell?.height ?? dim?.actualCellHeight ?? 18;
+      const screen = document.querySelector('.terminal-panel .xterm-screen') as HTMLElement;
+      const rect = screen.getBoundingClientRect();
+      // SELECT_ONSELECT_A is 17 chars long, on row 1 (after \r\n).
+      const startX = rect.left + 1;
+      const endX = rect.left + cw * 17 + cw * 0.6;
+      const y = rect.top + ch * 1.5;
+      return { startX, endX, y };
+    });
+
+    await window.mouse.move(coords.startX, coords.y);
+    await window.mouse.down();
+    await window.mouse.move(coords.endX, coords.y, { steps: 10 });
+    await window.mouse.up();
+    await window.waitForTimeout(300);
+
+    // No Ctrl+C, no right-click - the mouse-up alone should have copied.
+    const clip = await getClipboard(window);
+    expect(
+      clip,
+      `copy-on-select should put SELECT_ONSELECT_A on the clipboard at mouse-up; got: ${JSON.stringify(clip)}`,
+    ).toContain('SELECT_ONSELECT_A');
+    expect(clip).not.toBe('__STALE_ONSELECT_A__');
+  } finally {
+    await close();
+  }
+});
+
+test('copy-on-select: mouse-reporting TUI drag copies on mouse-up (no gesture)', async () => {
+  const { window, close } = await launchTmax();
+  try {
+    await window.waitForSelector('.terminal-panel', { timeout: 15_000 });
+    await window.waitForTimeout(800);
+
+    // SGR mouse reporting on: xterm forwards the drag, so there's no native
+    // selection - copy-on-select must fall back to the buffer snapshot.
+    await writeToTerminal(window, '\x1b[?1000h\x1b[?1006h\r\nSELECT_ONSELECT_B\r\n');
+    await window.waitForTimeout(300);
+
+    await window.click('.terminal-panel .xterm-screen');
+    await window.waitForTimeout(200);
+
+    await setClipboard(window, '__STALE_ONSELECT_B__');
+    await window.waitForTimeout(100);
+
+    const coords = await window.evaluate(() => {
+      const id = (window as any).__terminalStore.getState().focusedTerminalId;
+      const entry = (window as any).__getTerminalEntry(id);
+      const term = entry?.terminal;
+      const dim = (term as any)._core?._renderService?.dimensions;
+      const cw = dim?.css?.cell?.width ?? dim?.actualCellWidth ?? 9;
+      const ch = dim?.css?.cell?.height ?? dim?.actualCellHeight ?? 18;
+      const screen = document.querySelector('.terminal-panel .xterm-screen') as HTMLElement;
+      const rect = screen.getBoundingClientRect();
+      // SELECT_ONSELECT_B is 17 chars long, on row 1 (after \r\n).
+      const startX = rect.left + 1;
+      const endX = rect.left + cw * 17 + cw * 0.6;
+      const y = rect.top + ch * 1.5;
+      return { startX, endX, y };
+    });
+
+    await window.mouse.move(coords.startX, coords.y);
+    await window.mouse.down();
+    await window.mouse.move(coords.endX, coords.y, { steps: 10 });
+    await window.mouse.up();
+    await window.waitForTimeout(300);
+
+    const clip = await getClipboard(window);
+    expect(
+      clip,
+      `copy-on-select should copy the TUI-drag snapshot SELECT_ONSELECT_B at mouse-up; got: ${JSON.stringify(clip)}`,
+    ).toContain('SELECT_ONSELECT_B');
+    expect(clip).not.toBe('__STALE_ONSELECT_B__');
+  } finally {
+    await close();
+  }
+});

--- a/tests/e2e/copy-on-select.spec.ts
+++ b/tests/e2e/copy-on-select.spec.ts
@@ -22,6 +22,37 @@ async function writeToTerminal(window: Page, text: string): Promise<void> {
   }, text);
 }
 
+// Locate the marker's real position in the buffer and return drag coordinates
+// spanning it. Data-driven (not a hardcoded row) so a busy prompt / MOTD that
+// shifts the marker down doesn't make the drag miss - which would leave the
+// clipboard stale and fail for the wrong reason.
+async function dragCoordsForMarker(window: Page, marker: string) {
+  return window.evaluate((mk: string) => {
+    const id = (window as any).__terminalStore.getState().focusedTerminalId;
+    const entry = (window as any).__getTerminalEntry(id);
+    const term = entry?.terminal;
+    const buf = term.buffer.active;
+    let row = -1;
+    let col = -1;
+    for (let i = 0; i < buf.length; i++) {
+      const line = buf.getLine(i)?.translateToString(true) ?? '';
+      const idx = line.indexOf(mk);
+      if (idx >= 0) { row = i; col = idx; break; }
+    }
+    if (row < 0) return null;
+    const dim = (term as any)._core?._renderService?.dimensions;
+    const cw = dim?.css?.cell?.width ?? dim?.actualCellWidth ?? 9;
+    const ch = dim?.css?.cell?.height ?? dim?.actualCellHeight ?? 18;
+    const screen = document.querySelector('.terminal-panel .xterm-screen') as HTMLElement;
+    const rect = screen.getBoundingClientRect();
+    const viewportRow = row - buf.viewportY;
+    const startX = rect.left + cw * (col + 0.2);
+    const endX = rect.left + cw * (col + mk.length) + cw * 0.6;
+    const y = rect.top + ch * (viewportRow + 0.5);
+    return { startX, endX, y };
+  }, marker);
+}
+
 test('copy-on-select: native drag selection copies on mouse-up (no Ctrl+C, no right-click)', async () => {
   const { window, close } = await launchTmax();
   try {
@@ -38,25 +69,12 @@ test('copy-on-select: native drag selection copies on mouse-up (no Ctrl+C, no ri
     await setClipboard(window, '__STALE_ONSELECT_A__');
     await window.waitForTimeout(100);
 
-    const coords = await window.evaluate(() => {
-      const id = (window as any).__terminalStore.getState().focusedTerminalId;
-      const entry = (window as any).__getTerminalEntry(id);
-      const term = entry?.terminal;
-      const dim = (term as any)._core?._renderService?.dimensions;
-      const cw = dim?.css?.cell?.width ?? dim?.actualCellWidth ?? 9;
-      const ch = dim?.css?.cell?.height ?? dim?.actualCellHeight ?? 18;
-      const screen = document.querySelector('.terminal-panel .xterm-screen') as HTMLElement;
-      const rect = screen.getBoundingClientRect();
-      // SELECT_ONSELECT_A is 17 chars long, on row 1 (after \r\n).
-      const startX = rect.left + 1;
-      const endX = rect.left + cw * 17 + cw * 0.6;
-      const y = rect.top + ch * 1.5;
-      return { startX, endX, y };
-    });
+    const coords = await dragCoordsForMarker(window, 'SELECT_ONSELECT_A');
+    expect(coords, 'marker SELECT_ONSELECT_A should be found in the buffer').not.toBeNull();
 
-    await window.mouse.move(coords.startX, coords.y);
+    await window.mouse.move(coords!.startX, coords!.y);
     await window.mouse.down();
-    await window.mouse.move(coords.endX, coords.y, { steps: 10 });
+    await window.mouse.move(coords!.endX, coords!.y, { steps: 10 });
     await window.mouse.up();
     await window.waitForTimeout(300);
 
@@ -89,25 +107,12 @@ test('copy-on-select: mouse-reporting TUI drag copies on mouse-up (no gesture)',
     await setClipboard(window, '__STALE_ONSELECT_B__');
     await window.waitForTimeout(100);
 
-    const coords = await window.evaluate(() => {
-      const id = (window as any).__terminalStore.getState().focusedTerminalId;
-      const entry = (window as any).__getTerminalEntry(id);
-      const term = entry?.terminal;
-      const dim = (term as any)._core?._renderService?.dimensions;
-      const cw = dim?.css?.cell?.width ?? dim?.actualCellWidth ?? 9;
-      const ch = dim?.css?.cell?.height ?? dim?.actualCellHeight ?? 18;
-      const screen = document.querySelector('.terminal-panel .xterm-screen') as HTMLElement;
-      const rect = screen.getBoundingClientRect();
-      // SELECT_ONSELECT_B is 17 chars long, on row 1 (after \r\n).
-      const startX = rect.left + 1;
-      const endX = rect.left + cw * 17 + cw * 0.6;
-      const y = rect.top + ch * 1.5;
-      return { startX, endX, y };
-    });
+    const coords = await dragCoordsForMarker(window, 'SELECT_ONSELECT_B');
+    expect(coords, 'marker SELECT_ONSELECT_B should be found in the buffer').not.toBeNull();
 
-    await window.mouse.move(coords.startX, coords.y);
+    await window.mouse.move(coords!.startX, coords!.y);
     await window.mouse.down();
-    await window.mouse.move(coords.endX, coords.y, { steps: 10 });
+    await window.mouse.move(coords!.endX, coords!.y, { steps: 10 });
     await window.mouse.up();
     await window.waitForTimeout(300);
 


### PR DESCRIPTION
## What

Adds **copy-on-select**: selecting terminal text with the mouse copies it to the clipboard on mouse-up, so users never need Ctrl+C to copy.

## Why

In a Copilot CLI / Claude Code pane, **Ctrl+C is the interrupt/exit key**, and the TUI runs alt-screen + mouse tracking so a drag makes no native xterm selection. The existing snapshot (TASK-261) is reachable via Ctrl+C/right-click, but overloading Ctrl+C is inherently ambiguous with SIGINT. Copy-on-select sidesteps that: the copy happens on mouse-up, and **Ctrl+C handling is left completely untouched**.

## What changed

- `terminal.copyOnSelect` config flag (default `true`), read live like `smartUnwrapCopy`.
- `TerminalPanel` writes the selection to the clipboard on left mouse-up when a selection gesture occurred - native xterm selections (drag / double / triple-click) and mouse-reporting TUI drags (falls back to the existing `pendingTuiCopyRef` buffer snapshot). Runs through `smartUnwrapForCopy` with a whitespace guard.
- New Playwright specs: native-selection copy-on-select and TUI-drag copy-on-select.

## Not touched

- Ctrl+C / Ctrl+Shift+C / right-click / SIGINT paths are unchanged.
- `DetachedApp` (popped-out panes) - follow-up.

## Testing

- `tests/e2e/copy-on-select.spec.ts` (real drag + real clipboard read).
- Type-clean (no new `tsc` errors from this change).

Default is ON to deliver "copy that always works" out of the box; flip `terminal.copyOnSelect` to `false` to require an explicit copy gesture.
