### PR TITLE
fix(terminal): apply configured font size on startup

### DIFF
--- a/src/renderer/state/terminal-store.ts
+++ b/src/renderer/state/terminal-store.ts
@@ -1413,6 +1413,16 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
       updates.terminalOpacity = (config as any).terminalOpacity;
       document.documentElement.style.setProperty('--terminal-opacity', String((config as any).terminalOpacity));
     }
+    // Seed the live zoom size from the configured baseline. Without this the
+    // store keeps its hardcoded initial 14 and TerminalPanel's fontSize effect
+    // writes that back over the xterm instance on mount, so a configured size
+    // only ever took effect via updateConfig (Settings) or zoomReset (Ctrl+0)
+    // - never on startup. It also left the status-bar zoom badge showing
+    // 14 / configured instead of 100%.
+    const baseFontSize = config?.terminal?.fontSize;
+    if (typeof baseFontSize === 'number' && baseFontSize > 0) {
+      updates.fontSize = baseFontSize;
+    }
     // Seed AI session load limits from config so subsequent
     // loadCopilotSessions / loadClaudeCodeSessions calls in App.init
     // honor the user's preference (0 = no scan).

--- a/tests/unit/renderer/load-config-font-size.test.ts
+++ b/tests/unit/renderer/load-config-font-size.test.ts
@@ -1,0 +1,82 @@
+// loadConfig must seed the store's live zoom size from terminal.fontSize.
+//
+// Without it the store kept its hardcoded initial 14 while the status-bar
+// badge divided by the configured baseline, so a configured 17.5 rendered at
+// 14px and showed 80%. terminal-store reads window at module load, so the
+// stubs go in before a dynamic import (test env is 'node').
+import { describe, test, expect, beforeAll, beforeEach } from 'vitest';
+
+const getConfigResult: { value: unknown } = { value: {} };
+
+(globalThis as any).window = (globalThis as any).window ?? {};
+(globalThis as any).window.terminalAPI = {
+  getConfig: async () => getConfigResult.value,
+};
+(globalThis as any).document = (globalThis as any).document ?? {
+  hasFocus: () => true,
+  documentElement: { style: { setProperty: () => {} } },
+};
+
+let useTerminalStore: typeof import('../../../src/renderer/state/terminal-store').useTerminalStore;
+
+beforeAll(async () => {
+  ({ useTerminalStore } = await import('../../../src/renderer/state/terminal-store'));
+});
+
+beforeEach(() => {
+  // The hardcoded initial state, so each case starts from the pre-load value.
+  useTerminalStore.setState({ fontSize: 14 });
+});
+
+describe('loadConfig - terminal font size', () => {
+  test('seeds fontSize from the configured baseline', async () => {
+    getConfigResult.value = { terminal: { fontSize: 17.5 } };
+
+    await useTerminalStore.getState().loadConfig();
+
+    expect(useTerminalStore.getState().fontSize).toBe(17.5);
+  });
+
+  test('a configured baseline equal to the default is still applied', async () => {
+    getConfigResult.value = { terminal: { fontSize: 14 } };
+
+    await useTerminalStore.getState().loadConfig();
+
+    expect(useTerminalStore.getState().fontSize).toBe(14);
+  });
+
+  test('keeps the default when config carries no terminal section', async () => {
+    getConfigResult.value = {};
+
+    await useTerminalStore.getState().loadConfig();
+
+    expect(useTerminalStore.getState().fontSize).toBe(14);
+  });
+
+  test('ignores a non-numeric font size', async () => {
+    getConfigResult.value = { terminal: { fontSize: '18' } };
+
+    await useTerminalStore.getState().loadConfig();
+
+    expect(useTerminalStore.getState().fontSize).toBe(14);
+  });
+
+  test('ignores a zero or negative font size', async () => {
+    getConfigResult.value = { terminal: { fontSize: 0 } };
+    await useTerminalStore.getState().loadConfig();
+    expect(useTerminalStore.getState().fontSize).toBe(14);
+
+    getConfigResult.value = { terminal: { fontSize: -4 } };
+    await useTerminalStore.getState().loadConfig();
+    expect(useTerminalStore.getState().fontSize).toBe(14);
+  });
+
+  test('config itself is still stored alongside the seeded size', async () => {
+    getConfigResult.value = { terminal: { fontSize: 20 }, defaultShellId: 'zsh' };
+
+    await useTerminalStore.getState().loadConfig();
+
+    expect(useTerminalStore.getState().fontSize).toBe(20);
+    expect(useTerminalStore.getState().config?.terminal?.fontSize).toBe(20);
+  });
+});


### PR DESCRIPTION
### The bug

A terminal font size other than 14 does not survive a restart. On every launch the terminal renders at 14px regardless of `terminal.fontSize`, and the status-bar zoom badge shows a wrong percentage.

This affects the Settings font-size control just as much as editing `tmax-config.json` directly — the Settings change applies to the running session and is silently lost on the next start.

**Repro:** quit tmax, set `terminal.fontSize` to `17.5` (any value ≠ 14 reproduces), start tmax.

**Expected:** terminal renders at 17.5px, badge reads `100%`.
**Actual:** terminal renders at 14px, badge reads `80%` — exactly `14 / 17.5`.

### Root cause

`loadConfig` (`src/renderer/state/terminal-store.ts`) seeds `tabBarPosition`, `hideTabTitles`, `hideTabCloseButtons`, `confirmOnCloseSession`, `terminalOpacity` and the AI session limits from config into the store — but never `terminal.fontSize`. The store keeps its hardcoded initial `fontSize: 14`.

`TerminalPanel` *does* construct xterm with the configured size, but the effect that reacts to the store's `fontSize` writes the stale 14 straight back over the instance on mount, so the configured value never survives.

The store's `fontSize` was only ever reconciled with config in two places, neither of which runs at startup:

- `updateConfig` — runtime config changes, i.e. the Settings dialog
- `zoomReset` — <kbd>Ctrl</kbd>+<kbd>0</kbd>

That also explains the misleading badge: its numerator is the stale store value while its denominator is the freshly loaded config baseline.

### The fix

Seed `fontSize` from `config.terminal.fontSize` in `loadConfig`, alongside the fields it already copies. Guarded on a positive number so a malformed value falls back to the default rather than rendering an unusable terminal.

<kbd>Ctrl</kbd>+<kbd>0</kbd> keeps working unchanged — it reads the same baseline, which the store now already matches at startup.

### Testing

New unit suite `tests/unit/renderer/load-config-font-size.test.ts` (6 cases): seeding from config, a configured value equal to the default, config without a `terminal` section, non-numeric input, zero/negative input, and config still being stored alongside the seeded size.

Verified red/green — reverting the one-line seed fails 2 of the 6, applying it passes all 6.

`npm test` locally: 171 passed. Two failures in `telemetry-ping` are pre-existing on macOS and unrelated — they assert hardcoded `C:\Users\...` paths and fail identically on a clean checkout of `main`.

No cross-platform surface: no modifier keys, shortcut text, paths or shell assumptions involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
